### PR TITLE
Refactor use of getParentOp and getParentOfType

### DIFF
--- a/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
@@ -55,7 +55,7 @@ struct ConvertMhloRegionOpsToEmitCPass
       // ReduceOp
       auto funcWalkResult = func.walk([&](mhlo::ReduceOp op) {
         std::string funcName =
-            Twine(op.getParentOfType<FuncOp>().getName(), "_lambda_")
+            Twine(op->getParentOfType<FuncOp>().getName(), "_lambda_")
                 .concat(Twine(count++))
                 .str();
 
@@ -79,7 +79,7 @@ struct ConvertMhloRegionOpsToEmitCPass
       // ReduceWindowOp
       funcWalkResult = func.walk([&](mhlo::ReduceWindowOp op) {
         std::string funcName =
-            Twine(op.getParentOfType<FuncOp>().getName(), "_lambda_")
+            Twine(op->getParentOfType<FuncOp>().getName(), "_lambda_")
                 .concat(Twine(count++))
                 .str();
 

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -202,7 +202,7 @@ static LogicalResult printYieldOp(CppEmitter &emitter, emitc::YieldOp yieldOp) {
   if (yieldOp.getNumOperands() == 0) {
     return success();
   } else {
-    auto &parentOp = *yieldOp.getParentOp();
+    auto &parentOp = *yieldOp->getParentOp();
 
     for (uint result = 0; result < parentOp.getNumResults(); ++result) {
       os << emitter.getOrCreateName(parentOp.getResult(result)) << " = ";


### PR DESCRIPTION
'getParentOp' and 'getParentOfType' are deprecated. Use
Operation::getParentOp() and Operation::getParentOfType() instead.