### PR TITLE
Remove dimension specific typedefs

### DIFF
--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -371,7 +371,7 @@ inline Src logical_xor(Src x, Src y) {
 template <typename Dest, typename Src>
 inline Dest
 broadcast_in_dim(Src operand,
-                 Tensor1D<int64_t, Src::rank()> broadcast_dimensions) {
+                 Tensor<int64_t, Src::rank()> broadcast_dimensions) {
   static_assert(is_tensor<Src>::value, "Expected tensor argument");
   static_assert(is_tensor<Dest>::value, "Expected tensor result");
 
@@ -501,8 +501,8 @@ inline Dest concatenate(Src1 input1, Src... inputs) {
 // SliceOp
 // Overload for 1d case
 template <typename Dest, typename Src, IsTensorOfDim<1, Src> = true>
-Dest slice(Src x, Tensor1D<int64_t, 1> start_indices,
-           Tensor1D<int64_t, 1> limit_indices, Tensor1D<int64_t, 1> strides) {
+Dest slice(Src x, Tensor<int64_t, 1> start_indices,
+           Tensor<int64_t, 1> limit_indices, Tensor<int64_t, 1> strides) {
   Dest z;
 
   size_t index = 0;
@@ -515,8 +515,8 @@ Dest slice(Src x, Tensor1D<int64_t, 1> start_indices,
 
 // Overload for 2d case
 template <typename Dest, typename Src, IsTensorOfDim<2, Src> = true>
-Dest slice(Src x, Tensor1D<int64_t, 2> start_indices,
-           Tensor1D<int64_t, 2> limit_indices, Tensor1D<int64_t, 2> strides) {
+Dest slice(Src x, Tensor<int64_t, 2> start_indices,
+           Tensor<int64_t, 2> limit_indices, Tensor<int64_t, 2> strides) {
   Dest z;
 
   size_t index = 0;
@@ -531,8 +531,8 @@ Dest slice(Src x, Tensor1D<int64_t, 2> start_indices,
 
 // Overload for 3d case
 template <typename Dest, typename Src, IsTensorOfDim<3, Src> = true>
-Dest slice(Src x, Tensor1D<int64_t, 3> start_indices,
-           Tensor1D<int64_t, 3> limit_indices, Tensor1D<int64_t, 3> strides) {
+Dest slice(Src x, Tensor<int64_t, 3> start_indices,
+           Tensor<int64_t, 3> limit_indices, Tensor<int64_t, 3> strides) {
   Dest z;
 
   size_t index = 0;
@@ -550,8 +550,8 @@ Dest slice(Src x, Tensor1D<int64_t, 3> start_indices,
 
 // Overload for 4d case
 template <typename Dest, typename Src, IsTensorOfDim<4, Src> = true>
-Dest slice(Src x, Tensor1D<int64_t, 4> start_indices,
-           Tensor1D<int64_t, 4> limit_indices, Tensor1D<int64_t, 4> strides) {
+Dest slice(Src x, Tensor<int64_t, 4> start_indices,
+           Tensor<int64_t, 4> limit_indices, Tensor<int64_t, 4> strides) {
   Dest z;
 
   size_t index = 0;
@@ -574,16 +574,16 @@ Dest slice(Src x, Tensor1D<int64_t, 4> start_indices,
 // Overload for 1d case
 template <typename Dest, typename Src, IsTensorOfDim<1, Src> = true>
 Dest dynamic_slice(Src x, Tensor<int32_t> start_index,
-                   Tensor1D<int64_t, 1> slice_sizes) {
+                   Tensor<int64_t, 1> slice_sizes) {
   auto clamp = [](int64_t value, int64_t minValue, int64_t maxValue) {
     return std::max(minValue, std::min(maxValue, value));
   };
 
   int64_t dim_x = static_cast<int64_t>(Src::dim(0));
   int64_t start_index_eff = clamp(start_index[0], 0, dim_x - slice_sizes[0]);
-  Tensor1D<int64_t, 1> start_indices{start_index_eff};
-  Tensor1D<int64_t, 1> limit_indices{start_index_eff + slice_sizes[0]};
-  Tensor1D<int64_t, 1> strides{1};
+  Tensor<int64_t, 1> start_indices{start_index_eff};
+  Tensor<int64_t, 1> limit_indices{start_index_eff + slice_sizes[0]};
+  Tensor<int64_t, 1> strides{1};
 
   return slice<Dest, Src>(x, start_indices, limit_indices, strides);
 }
@@ -592,7 +592,7 @@ Dest dynamic_slice(Src x, Tensor<int32_t> start_index,
 template <typename Dest, typename Src, IsTensorOfDim<2, Src> = true>
 Dest dynamic_slice(Src x, Tensor<int32_t> start_index_x,
                    Tensor<int32_t> start_index_y,
-                   Tensor1D<int64_t, 2> slice_sizes) {
+                   Tensor<int64_t, 2> slice_sizes) {
   auto clamp = [](int64_t value, int64_t minValue, int64_t maxValue) {
     return std::max(minValue, std::min(maxValue, value));
   };
@@ -603,10 +603,10 @@ Dest dynamic_slice(Src x, Tensor<int32_t> start_index_x,
       clamp(start_index_x[0], 0, dim_x - slice_sizes[0]);
   int64_t start_index_y_eff =
       clamp(start_index_y[0], 0, dim_y - slice_sizes[1]);
-  Tensor1D<int64_t, 2> start_indices{start_index_x_eff, start_index_y_eff};
-  Tensor1D<int64_t, 2> limit_indices{start_index_x_eff + slice_sizes[0],
-                                     start_index_y_eff + slice_sizes[1]};
-  Tensor1D<int64_t, 2> strides{1, 1};
+  Tensor<int64_t, 2> start_indices{start_index_x_eff, start_index_y_eff};
+  Tensor<int64_t, 2> limit_indices{start_index_x_eff + slice_sizes[0],
+                                   start_index_y_eff + slice_sizes[1]};
+  Tensor<int64_t, 2> strides{1, 1};
 
   return slice<Dest, Src>(x, start_indices, limit_indices, strides);
 }
@@ -891,7 +891,7 @@ inline Src select(typename replace_element_type<bool, Src>::type pred,
 // RngUniformOp
 template <typename Dest, typename T, size_t N>
 inline Dest rng_uniform(Tensor<T> low, Tensor<T> high,
-                        Tensor1D<int64_t, N> shape) {
+                        Tensor<int64_t, N> shape) {
   static_assert(std::is_integral<T>::value || std::is_floating_point<T>::value,
                 "Expected integer or floating point type");
   using uniform_distribution =
@@ -983,17 +983,17 @@ Src batch_norm_inference(Src input, Feature scale, Feature offset, Feature mean,
 template <typename Dest, typename Src, typename Weights>
 Dest convolution(Src input, Weights weights, int64_t batch_group_count,
                  int64_t input_batch_dimension, int64_t input_feature_dimension,
-                 Tensor1D<int64_t, 2> input_spatial_dimensions,
+                 Tensor<int64_t, 2> input_spatial_dimensions,
                  int64_t kernel_input_feature_dimension,
                  int64_t kernel_output_feature_dimension,
-                 Tensor1D<int64_t, 2> kernel_spatial_dimensions,
+                 Tensor<int64_t, 2> kernel_spatial_dimensions,
                  int64_t output_batch_dimension,
                  int64_t output_feature_dimension,
-                 Tensor1D<int64_t, 2> output_spatial_dimensions,
-                 int64_t feature_group_count, Tensor2D<int64_t, 2, 2> padding,
-                 Tensor1D<int64_t, 2> lhs_dilation,
-                 Tensor1D<int64_t, 2> rhs_dilation,
-                 Tensor1D<int64_t, 2> window_strides) {
+                 Tensor<int64_t, 2> output_spatial_dimensions,
+                 int64_t feature_group_count, Tensor<int64_t, 2, 2> padding,
+                 Tensor<int64_t, 2> lhs_dilation,
+                 Tensor<int64_t, 2> rhs_dilation,
+                 Tensor<int64_t, 2> window_strides) {
   static_assert(is_tensor_of_dim<4, Src>::value,
                 "Expected 4 dimensional input");
   static_assert(is_tensor_of_dim<4, Dest>::value,

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -543,9 +543,7 @@ LogicalResult CppEmitter::emitType(Type type) {
   if (auto itype = type.dyn_cast<TensorType>()) {
     if (!itype.hasRank())
       return failure();
-    os << "Tensor";
-    os << itype.getRank();
-    os << "D<";
+    os << "Tensor<";
     emitType(itype.getElementType());
     auto shape = itype.getShape();
     for (auto dimSize : shape) {

--- a/test/Conversion/mhlo-to-std.mlir
+++ b/test/Conversion/mhlo-to-std.mlir
@@ -1,6 +1,6 @@
 // RUN: emitc-opt -convert-mhlo-const-to-std %s | emitc-translate --mlir-to-cpp | FileCheck %s
 
-// CHECK: Tensor1D<int32_t, 2> mhlo_constant(Tensor1D<int32_t, 2> v1)
+// CHECK: Tensor<int32_t, 2> mhlo_constant(Tensor<int32_t, 2> v1)
 func @mhlo_constant(%arg0: tensor<2xi32>) -> tensor<2xi32> {
   %0 = "mhlo.constant"() {value = dense<1> : tensor<2xi32>} : () -> tensor<2xi32>
   // CHECK: return v2;

--- a/test/Conversion/std-to-emitc.mlir
+++ b/test/Conversion/std-to-emitc.mlir
@@ -1,20 +1,20 @@
 // RUN: emitc-opt -convert-std-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s
 
-// CHECK: Tensor1D<size_t, 2> std_index_cast(Tensor0D<size_t> v1, Tensor1D<int32_t, 2> v2, Tensor2D<int32_t, 2, 2> v3)
+// CHECK: Tensor<size_t, 2> std_index_cast(Tensor<size_t> v1, Tensor<int32_t, 2> v2, Tensor<int32_t, 2, 2> v3)
 func @std_index_cast(%arg0: tensor<index>, %arg1: tensor<2xi32>, %arg2: tensor<2x2xi32>) -> tensor<2xindex> {
-  // CHECK: standard::index_cast<Tensor0D<int32_t>>(v1)
+  // CHECK: standard::index_cast<Tensor<int32_t>>(v1)
   %0 = "std.index_cast"(%arg0) : ( tensor<index>) -> tensor<i32>
-  // CHECK: standard::index_cast<Tensor1D<size_t, 2>>(v2)
+  // CHECK: standard::index_cast<Tensor<size_t, 2>>(v2)
   %1 = "std.index_cast"(%arg1) : (tensor<2xi32>) -> tensor<2xindex>
-  // CHECK: standard::index_cast<Tensor2D<size_t, 2, 2>>(v3)
+  // CHECK: standard::index_cast<Tensor<size_t, 2, 2>>(v3)
   %2 = "std.index_cast"(%arg2) : (tensor<2x2xi32>) -> tensor<2x2xindex>
   // CHECK: return v5;
   return %1 : tensor<2xindex>
 }
 
-// CHECK: Tensor1D<float, 8> splat_op(float v1)
+// CHECK: Tensor<float, 8> splat_op(float v1)
 func @splat_op(%s : f32) -> tensor<8xf32> {
-  // CHECK: standard::splat<Tensor1D<float, 8>>(v1)
+  // CHECK: standard::splat<Tensor<float, 8>>(v1)
   %t = splat %s : tensor<8xf32>
   return %t : tensor<8xf32>
 }

--- a/test/Conversion/tensor-to-emitc.mlir
+++ b/test/Conversion/tensor-to-emitc.mlir
@@ -1,6 +1,6 @@
 // RUN: emitc-opt -convert-tensor-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s
 
-// CHECK: void std_extract_element(Tensor0D<int32_t> v1, Tensor1D<int32_t, 2> v2)
+// CHECK: void std_extract_element(Tensor<int32_t> v1, Tensor<int32_t, 2> v2)
 func @std_extract_element(%arg0: tensor<i32>, %arg1: tensor<2xi32>) -> () {
   %0 = constant 0 : index
   %1 = constant 1 : index

--- a/test/Target/cpp-calls.mlir
+++ b/test/Target/cpp-calls.mlir
@@ -57,14 +57,14 @@ func @test_plus_int(%arg0 : i64) -> i64 {
   return %0 : i64
 }
 
-// CHECK: Tensor1D<float, 2> mixed_types(Tensor1D<double, 2> [[V1]])
+// CHECK: Tensor<float, 2> mixed_types(Tensor<double, 2> [[V1]])
 func @mixed_types(%arg0: tensor<2xf64>) -> tensor<2xf32> {
   // CHECK: foo::mixed_types([[V1]]);
   %0 = emitc.call "foo::mixed_types"(%arg0) {args = [0 : index]} : (tensor<2xf64>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
-// CHECK: Tensor0D<uint64_t> mhlo_convert(Tensor0D<uint32_t> [[V1]])
+// CHECK: Tensor<uint64_t> mhlo_convert(Tensor<uint32_t> [[V1]])
 func @mhlo_convert(%arg0: tensor<ui32>) -> tensor<ui64> {
   // CHECK: mhlo::convert([[V1]]);
   %0 = emitc.call "mhlo::convert"(%arg0) {args = [0 : index]} : (tensor<ui32>) -> tensor<ui64>


### PR DESCRIPTION
These were leftovers from the move to a variadic template for the Tensor type.