### PR TITLE
Generalize e2e pipeline test to work with keras and tensorflow saved models

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -93,7 +93,7 @@ jobs:
         mkdir -p tmp
         cd tmp
         python3 ../${EMITC}/scripts/get_mobilenet_v2.py
-        python3 ../${EMITC}/scripts/keras_to_savedmodel.py --batch-size 2 mobilenet_v2.h5 model
+        python3 ../${EMITC}/scripts/model_to_savedmodel_with_predict_function.py --batch-size 2 mobilenet_v2.h5 model
         python3 ../${EMITC}/scripts/savedmodel_to_tf_dialect.py --exported-names predict model model_tf.mlir
         python3 ../${EMITC}/scripts/optimize_tf_dialect.py model_tf.mlir model_tf_opt.mlir
         python3 ../${EMITC}/scripts/tf_to_mhlo_dialect.py model_tf_opt.mlir ../${E2E}/model_mhlo.mlir

--- a/scripts/model_to_savedmodel_with_predict_function.py
+++ b/scripts/model_to_savedmodel_with_predict_function.py
@@ -53,7 +53,7 @@ def main():
     parser = argparse.ArgumentParser(
         description=
         "Translates a model to saved model format with a predict function for further compiling." \
-        "Both keras and saved model format as input is supported."
+        "Keras and saved model format are supported as input formats."
     )
     parser.add_argument(
         "--batch-size",

--- a/scripts/model_to_savedmodel_with_predict_function.py
+++ b/scripts/model_to_savedmodel_with_predict_function.py
@@ -41,24 +41,32 @@ def translate(model_path: str, output_path: str, batch_size: int):
 
     # Produce a concrete function to compile.
     module = Module(model)
-    module.predict = tf.function(func=module.predict,
-                                 input_signature=extract_tensor_specs(
-                                     model, batch_size=batch_size))
+    module.predict = tf.function(
+        func=module.predict,
+        input_signature=extract_tensor_specs(model, batch_size=batch_size),
+    )
 
     tf.saved_model.save(module, output_path)
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Translate keras model to saved model format")
+        description=
+        "Translates a model to saved model format with a predict function for further compiling." \
+        "Both keras and saved model format as input is supported."
+    )
     parser.add_argument(
         "--batch-size",
         type=int,
         default=1,
         help="Set the batch size for inference",
     )
-    parser.add_argument("model_path", metavar="model-path", help="Path to keras model")
-    parser.add_argument("output_path", metavar="output-path", help="Output directory")
+    parser.add_argument("model_path",
+                        metavar="model-path",
+                        help="Path to model")
+    parser.add_argument("output_path",
+                        metavar="output-path",
+                        help="Output directory")
     args = parser.parse_args()
 
     translate(args.model_path, args.output_path, args.batch_size)


### PR DESCRIPTION
The existing test pipeline already worked with both keras and tensorflow saved models, hence I generalized the naming and the content of the scripts. Since I renamed the script, I also updated the github build-and-test.yaml. 

Furthermore the test case generator can now handle int32 as output type of operations.