### PR TITLE
Bump CMake minimum to 3.13.4 and remove dead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,8 @@
-cmake_minimum_required(VERSION 3.10)
-
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 NEW)
-  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
-endif()
-
-if(POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
+cmake_minimum_required(VERSION 3.13.4)
 project(mlir-emitc LANGUAGES CXX C)
+
+set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 


### PR DESCRIPTION
The upstream CMake minimum was bumped with llvm/llvm-project@afa1afd.
This allows to remove dead code setting policies to NEW, see the
upstream commit llvm/llvm-project@480643a.