### PR TITLE
Introduce core ops header and move mhlo::abs to it

### DIFF
--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -1,0 +1,44 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines the EmitC core ops
+
+#ifndef EMITC_EMITC_CORE_OPS_H
+#define EMITC_EMITC_CORE_OPS_H
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <type_traits>
+#include <vector>
+
+#include "emitc_types.h"
+
+namespace emitc {
+
+// AbsOp
+// TODO support complex numbers
+template <typename Src>
+inline Src abs(Src x) {
+  using ET_Src = typename get_element_type<Src>::type;
+
+  auto f = static_cast<ET_Src (*)(ET_Src)>(std::abs);
+
+  return unary<Src>(x, f);
+}
+
+} // namespace emitc
+
+#endif // EMITC_EMITC_CORE_OPS_H

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file defines functions used by EmitC
+// This file defines functions emitted by MHLOToEmitC
 
 #ifndef EMITC_EMITC_MHLO_H
 #define EMITC_EMITC_MHLO_H
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "emitc_types.h"
+#include "emitc_core_ops.h"
 
 namespace mhlo {
 /// See
@@ -37,11 +37,7 @@ namespace mhlo {
 // TODO support complex numbers
 template <typename Src>
 inline Src abs(Src x) {
-  using ET_Src = typename get_element_type<Src>::type;
-
-  auto f = static_cast<ET_Src (*)(ET_Src)>(std::abs);
-
-  return unary<Src>(x, f);
+  return emitc::abs<Src>(x);
 }
 
 // CeilOp


### PR DESCRIPTION
This introduces are core ops header in which common ops are implemented.
Those common ops can be called/used from different conversion passes.