### PR TITLE
Add TOSA add and exp operations

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -6,3 +6,6 @@ The table below shows the supported TOSA ops.
 | :-------------------- |:------------------:| :------ |
 | **Unary elementwise ops**
 | abs                   | :heavy_check_mark: | |
+| exp                   | :heavy_check_mark: | |
+| **Binary elementwise ops**
+| add                   | :heavy_check_mark: | |

--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -39,6 +39,17 @@ inline Src abs(Src x) {
   return unary<Src>(x, f);
 }
 
+/// Functions for binary elementwise ops.
+// AddOp
+template <typename Src>
+inline Src add(Src x, Src y) {
+  using ET_Src = typename get_element_type<Src>::type;
+
+  auto f = std::plus<ET_Src>{};
+
+  return binary<Src>(x, y, f);
+}
+
 } // namespace emitc
 
 #endif // EMITC_EMITC_CORE_OPS_H

--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -28,6 +28,7 @@
 
 namespace emitc {
 
+/// Functions for unary elementwise ops
 // AbsOp
 // TODO support complex numbers
 template <typename Src>
@@ -35,6 +36,16 @@ inline Src abs(Src x) {
   using ET_Src = typename get_element_type<Src>::type;
 
   auto f = static_cast<ET_Src (*)(ET_Src)>(std::abs);
+
+  return unary<Src>(x, f);
+}
+
+// ExpOp
+template <typename Src>
+inline Src exp(Src x) {
+  using ET_Src = typename get_element_type<Src>::type;
+
+  auto f = static_cast<ET_Src (*)(ET_Src)>(std::exp);
 
   return unary<Src>(x, f);
 }

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -103,11 +103,7 @@ inline Src cos(Src x) {
 // ExpOp
 template <typename Src>
 inline Src exponential(Src x) {
-  using ET_Src = typename get_element_type<Src>::type;
-
-  auto f = static_cast<ET_Src (*)(ET_Src)>(std::exp);
-
-  return unary<Src>(x, f);
+  return emitc::exp<Src>(x);
 }
 
 // Expm1Op

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -218,11 +218,7 @@ inline Src tanh(Src x) {
 // AddOp
 template <typename Src>
 inline Src add(Src x, Src y) {
-  using ET_Src = typename get_element_type<Src>::type;
-
-  auto f = std::plus<ET_Src>{};
-
-  return binary<Src>(x, y, f);
+  return emitc::add<Src>(x, y);
 }
 
 // Atan2Op

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -32,7 +32,7 @@ inline Src exp(Src x) {
   return emitc::exp<Src>(x);
 }
 
-/// Binary elementwise ops	
+/// Binary elementwise ops
 // AddOp
 template <typename Src>
 inline Src add(Src x, Src y) {

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -19,10 +19,17 @@
 
 namespace tosa {
 
+/// Unary elementwise ops
 // AbsOp
 template <typename Src>
 inline Src abs(Src x) {
   return emitc::abs<Src>(x);
+}
+
+// ExpOp
+template <typename Src>
+inline Src exp(Src x) {
+  return emitc::exp<Src>(x);
 }
 
 /// Binary elementwise ops	

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -25,6 +25,13 @@ inline Src abs(Src x) {
   return emitc::abs<Src>(x);
 }
 
+/// Binary elementwise ops	
+// AddOp
+template <typename Src>
+inline Src add(Src x, Src y) {
+  return emitc::add<Src>(x, y);
+}
+
 } // namespace tosa
 
 #endif // EMITC_EMITC_TOSA_H

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -81,7 +81,7 @@ void populateTosaToEmitcPatterns(MLIRContext *ctx,
   patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "tosa::abs");
   patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "tosa::exp");
 
-  // Binary elementwise ops	
+  // Binary elementwise ops
   patterns.insert<CallOpConversion<tosa::AddOp>>(ctx, "tosa::add");
 }
 
@@ -106,7 +106,7 @@ struct ConvertTosaToEmitCPass
     target.addIllegalOp<tosa::AbsOp>();
     target.addIllegalOp<tosa::ExpOp>();
 
-    // Binary elementwise ops	
+    // Binary elementwise ops
     target.addIllegalOp<tosa::AddOp>();
 
     OwningRewritePatternList patterns;

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -76,7 +76,10 @@ private:
 
 void populateTosaToEmitcPatterns(MLIRContext *ctx,
                                  OwningRewritePatternList &patterns) {
+
+  // Unary elementwise ops
   patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "tosa::abs");
+  patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "tosa::exp");
 
   // Binary elementwise ops	
   patterns.insert<CallOpConversion<tosa::AddOp>>(ctx, "tosa::add");
@@ -99,7 +102,9 @@ struct ConvertTosaToEmitCPass
     // target.addLegalOp<ModuleOp>();
     // target.addLegalOp<ModuleTerminatorOp>();
 
+    // Unary elementwise ops
     target.addIllegalOp<tosa::AbsOp>();
+    target.addIllegalOp<tosa::ExpOp>();
 
     // Binary elementwise ops	
     target.addIllegalOp<tosa::AddOp>();

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -77,6 +77,9 @@ private:
 void populateTosaToEmitcPatterns(MLIRContext *ctx,
                                  OwningRewritePatternList &patterns) {
   patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "tosa::abs");
+
+  // Binary elementwise ops	
+  patterns.insert<CallOpConversion<tosa::AddOp>>(ctx, "tosa::add");
 }
 
 namespace {
@@ -97,6 +100,9 @@ struct ConvertTosaToEmitCPass
     // target.addLegalOp<ModuleTerminatorOp>();
 
     target.addIllegalOp<tosa::AbsOp>();
+
+    // Binary elementwise ops	
+    target.addIllegalOp<tosa::AddOp>();
 
     OwningRewritePatternList patterns;
     populateTosaToEmitcPatterns(&getContext(), patterns);

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -5,3 +5,12 @@ func @test_abs(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   %0 = "tosa.abs"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
+
+/// Binary elementwise ops
+
+// CHECK-LABEL: add
+func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  // CHECK: emitc.call "tosa::add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  %0 = "tosa.add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  return %0 : tensor<13x21x3xf32>
+}

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -1,14 +1,21 @@
 // RUN: emitc-opt -convert-tosa-to-emitc %s | FileCheck %s
 
+/// Unary elementwise ops
+
 func @test_abs(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: emitc.call "tosa::abs"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.abs"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
+func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  // CHECK: emitc.call "tosa::exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  %0 = "tosa.exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  return %0 : tensor<13x21x3xf32>
+}
+
 /// Binary elementwise ops
 
-// CHECK-LABEL: add
 func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: emitc.call "tosa::add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -9,7 +9,7 @@ func @test_abs(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 }
 
 func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "tosa::exp"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
@@ -17,7 +17,7 @@ func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 /// Binary elementwise ops
 
 func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "tosa::add"(%arg0, %arg1) {template_args = []} : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }


### PR DESCRIPTION
Adds `add` and `exp` operations to `emitc_tosa.h` and corresponding tests. To achieve a shared implementation between mhlo and tosa these ops were moved from `emitc_mhlo.h` to `emitc_core_ops.h`.