### PR TITLE
Add conversions for tosa.reciprocal and tosa.rsqrt.

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -7,6 +7,7 @@ The table below shows the supported TOSA ops.
 | **Unary elementwise ops**
 | abs                   | :heavy_check_mark: | |
 | exp                   | :heavy_check_mark: | |
+| reciprocal            | :heavy_check_mark: | |
 | rsqrt                 | :heavy_check_mark: | |
 | **Binary elementwise ops**
 | add                   | :heavy_check_mark: | |

--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -7,5 +7,6 @@ The table below shows the supported TOSA ops.
 | **Unary elementwise ops**
 | abs                   | :heavy_check_mark: | |
 | exp                   | :heavy_check_mark: | |
+| rsqrt                 | :heavy_check_mark: | |
 | **Binary elementwise ops**
 | add                   | :heavy_check_mark: | |

--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -50,6 +50,16 @@ inline Src exp(Src x) {
   return unary<Src>(x, f);
 }
 
+// SqrtOp
+template <typename Src>
+inline Src sqrt(Src x) {
+  using ET_Src = typename get_element_type<Src>::type;
+
+  auto f = static_cast<ET_Src (*)(ET_Src)>(std::sqrt);
+
+  return unary<Src>(x, f);
+}
+
 /// Functions for binary elementwise ops.
 // AddOp
 template <typename Src>

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -193,11 +193,7 @@ inline Src sin(Src x) {
 // SqrtOp
 template <typename Src>
 inline Src sqrt(Src x) {
-  using ET_Src = typename get_element_type<Src>::type;
-
-  auto f = static_cast<ET_Src (*)(ET_Src)>(std::sqrt);
-
-  return unary<Src>(x, f);
+  return emitc::sqrt<Src>(x);
 }
 
 // TanhOp

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -32,6 +32,16 @@ inline Src exp(Src x) {
   return emitc::exp<Src>(x);
 }
 
+// ReciprocalOp
+template <typename Src>
+inline Src reciprocal(Src x) {
+  using ET_Src = typename get_element_type<Src>::type;
+
+  auto f = [](ET_Src element) { return (static_cast<ET_Src>(1.0) / element); };
+
+  return unary<Src>(x, f);
+}
+
 /// Binary elementwise ops
 // AddOp
 template <typename Src>

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -121,6 +121,8 @@ void populateTosaToEmitcPatterns(MLIRContext *ctx,
   // Unary elementwise ops
   patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "tosa::abs");
   patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "tosa::exp");
+  patterns.insert<CallOpConversion<tosa::ReciprocalOp>>(ctx,
+                                                        "tosa::reciprocal");
   patterns.insert<RsqrtOpConversion>(ctx);
 
   // Binary elementwise ops
@@ -147,6 +149,7 @@ struct ConvertTosaToEmitCPass
     // Unary elementwise ops
     target.addIllegalOp<tosa::AbsOp>();
     target.addIllegalOp<tosa::ExpOp>();
+    target.addIllegalOp<tosa::ReciprocalOp>();
     target.addIllegalOp<tosa::RsqrtOp>();
 
     // Binary elementwise ops

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -24,8 +24,6 @@ namespace emitc {
 
 namespace {
 
-/// Common functions
-/// Adopted from mlir-hlo
 template <typename SrcOp>
 class CallOpConversion : public OpConversionPattern<SrcOp> {
   using OpConversionPattern<SrcOp>::OpConversionPattern;
@@ -85,11 +83,8 @@ private:
   LogicalResult
   matchAndRewrite(tosa::RsqrtOp rsqrtOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    // no args or template args - shared between ops
     ArrayAttr args;
-    SmallVector<Attribute, 0> templateArgs_;
-    ArrayAttr templateArgs =
-        ArrayAttr::get(rsqrtOp.getContext(), templateArgs_);
+    ArrayAttr templateArgs;
 
     // create sqrt op
     StringRef sqrtFuncName = "emitc::sqrt";

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -14,6 +14,13 @@ func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   return %0 : tensor<13x21x3xf32>
 }
 
+func @test_rsqrt(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  // CHECK: %0 = emitc.call "emitc::sqrt"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "tosa::reciprocal"(%0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  %0 = "tosa.rsqrt"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  return %0 : tensor<13x21x3xf32>
+}
+
 /// Binary elementwise ops
 
 func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -21,8 +21,8 @@ func @test_reciprocal(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 }
 
 func @test_rsqrt(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "emitc::sqrt"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reciprocal"(%0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::sqrt"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "tosa::reciprocal"(%0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.rsqrt"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -14,6 +14,12 @@ func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   return %0 : tensor<13x21x3xf32>
 }
 
+func @test_reciprocal(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  // CHECK: %0 = emitc.call "tosa::reciprocal"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  %0 = "tosa.reciprocal"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  return %0 : tensor<13x21x3xf32>
+}
+
 func @test_rsqrt(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: %0 = emitc.call "emitc::sqrt"(%arg0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   // CHECK: %1 = emitc.call "tosa::reciprocal"(%0) {template_args = []} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_mlir_unittest(MLIREmitCAllTests emitc_mhlo.cpp emitc_std.cpp emitc_tensor.cpp emitc_types.cpp)
+add_mlir_unittest(MLIREmitCAllTests emitc_mhlo.cpp emitc_std.cpp emitc_tensor.cpp emitc_tosa.cpp emitc_types.cpp)
 
 target_include_directories(MLIREmitCAllTests
   PRIVATE ${gtest_SOURCE_DIR}/include

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -1,0 +1,34 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+
+#include "emitc/emitc_tosa.h"
+#include "emitc/emitc_types.h"
+
+namespace {
+
+using ::testing::FloatNear;
+using ::testing::Pointwise;
+
+const float EPSILON = 5e-4;
+
+TEST(tosa, reciprocal) {
+  Tensor<float, 4> t0{1.0f, 2.0f, 3.0f, 4.0f};
+  Tensor<float, 4> excpected{1.0f, 0.5f, 0.3333f, 0.25f};
+
+  Tensor<float, 4> result = tosa::reciprocal(t0);
+
+  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), excpected));
+}
+
+} // namespace


### PR DESCRIPTION
This adds conversions for `tosa.reciprocal` and `tosa.rsqrt`. Also adds tests for conversions and functions. `tosa.rsqrt` is splitted into two `emitc::CallOp`: `emitc::sqrt` and `tosa::reciprocal`.