### PR TITLE
Implement basic ConstOp

### DIFF
--- a/docs/EmitC.md
+++ b/docs/EmitC.md
@@ -55,6 +55,31 @@ specifying order of operands and attributes in the call as follows:
 | :----: | ----------- |
 &laquo;unnamed&raquo; | any type
 
+### `emitc.const` (::mlir::emitc::ConstOp)
+
+Constant op
+
+Syntax:
+
+```
+operation ::= ssa-id `=` `emitc.const` attribute-value `:` type
+```
+
+In addition to the `std.constant` operation, the `emitc.const` operation
+is intended to support opaque attributes and the EmitC's opaque type.
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`value` | ::mlir::Attribute | any attribute
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+&laquo;unnamed&raquo; | any type
+
 ### `emitc.for` (::mlir::emitc::ForOp)
 
 for operation

--- a/docs/EmitC.md
+++ b/docs/EmitC.md
@@ -59,14 +59,10 @@ specifying order of operands and attributes in the call as follows:
 
 Constant op
 
-Syntax:
-
-```
-operation ::= ssa-id `=` `emitc.const` attribute-value `:` type
-```
-
+The `const` operation produces an SSA value equal to some constant
+specified by an attribute, similar to `std.constant`.
 In addition to the `std.constant` operation, the `emitc.const` operation
-is intended to support opaque attributes and the EmitC's opaque type.
+is intended to support opaque attributes and EmitC's opaque type.
 
 #### Attributes:
 

--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -102,14 +102,10 @@ def EmitC_CallOp : EmitC_Op<"call", []> {
 def EmitC_ConstOp : EmitC_Op<"const", [ConstantLike, NoSideEffect]> {
   let summary = "Constant op";
   let description = [{
-    Syntax:
-
-    ```
-    operation ::= ssa-id `=` `emitc.const` attribute-value `:` type
-    ```
-
+    The `const` operation produces an SSA value equal to some constant
+    specified by an attribute, similar to `std.constant`.
     In addition to the `std.constant` operation, the `emitc.const` operation
-    is intended to support opaque attributes and the EmitC's opaque type.
+    is intended to support opaque attributes and EmitC's opaque type.
   }];
 
   let arguments = (ins AnyAttr:$value);

--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -24,6 +24,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 def EmitC_Dialect : Dialect {
   let name = "emitc";
   let cppNamespace = "::mlir::emitc";
+  let hasConstantMaterializer = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -96,6 +97,25 @@ def EmitC_CallOp : EmitC_Op<"call", []> {
   let assemblyFormat = [{
     $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
   }];
+}
+
+def EmitC_ConstOp : EmitC_Op<"const", [ConstantLike, NoSideEffect]> {
+  let summary = "Constant op";
+  let description = [{
+    Syntax:
+
+    ```
+    operation ::= ssa-id `=` `emitc.const` attribute-value `:` type
+    ```
+
+    In addition to the `std.constant` operation, the `emitc.const` operation
+    is intended to support opaque attributes and the EmitC's opaque type.
+  }];
+
+  let arguments = (ins AnyAttr:$value);
+  let results = (outs AnyType);
+
+  let hasFolder = 1;
 }
 
 def EmitC_GetAddressOfOp : EmitC_Op<"getaddressof", []> {

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -37,9 +37,27 @@ void emitc::EmitCDialect::initialize() {
       >();
 }
 
+/// Materialize a single constant operation from a given attribute value with
+/// the desired resultant type.
+Operation *emitc::EmitCDialect::materializeConstant(OpBuilder &builder,
+                                                    Attribute value, Type type,
+                                                    Location loc) {
+  return builder.create<ConstantOp>(loc, type, value);
+}
+
 /// Default callback for IfOp builders. Inserts a yield without arguments.
 void emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
   builder.create<emitc::YieldOp>(loc);
+}
+
+//===----------------------------------------------------------------------===//
+// ConstOp
+//===----------------------------------------------------------------------===//
+// Folder
+
+OpFoldResult ConstOp::fold(ArrayRef<Attribute> operands) {
+  assert(operands.empty() && "constant has no operands");
+  return value();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -60,11 +60,14 @@ static LogicalResult printConstOp(CppEmitter &emitter, ConstOp constOp) {
   auto value = constOp.value();
   bool emitBraces = value.isa<FloatAttr>() || value.isa<IntegerAttr>();
 
+  if (constOp.getType().dyn_cast<emitc::OpaqueType>()) {
+    // TODO: Refactor me! We have to improve the checks in the dialect.
+    emitBraces = false;
+    os << " = ";
+  }
+
   if (emitBraces)
     os << "{";
-
-  if (constOp.getType().dyn_cast<emitc::OpaqueType>())
-    os << " = ";
 
   if (failed(emitter.emitAttribute(constOp.value())))
     return constOp.emitError("unable to emit constant value");

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -49,6 +49,32 @@ static LogicalResult printConstantOp(CppEmitter &emitter,
   return success();
 }
 
+static LogicalResult printConstOp(CppEmitter &emitter, ConstOp constOp) {
+  auto &os = emitter.ostream();
+  if (failed(emitter.emitType(constOp.getType())))
+    return failure();
+  os << " " << emitter.getOrCreateName(constOp.getResult());
+
+  // Add braces for number literals only to avoid double brace intialization for
+  // tensors.
+  auto value = constOp.value();
+  bool emitBraces = value.isa<FloatAttr>() || value.isa<IntegerAttr>();
+
+  if (emitBraces)
+    os << "{";
+
+  if (constOp.getType().dyn_cast<emitc::OpaqueType>())
+    os << " = ";
+
+  if (failed(emitter.emitAttribute(constOp.value())))
+    return constOp.emitError("unable to emit constant value");
+
+  if (emitBraces)
+    os << "}";
+
+  return success();
+}
+
 static LogicalResult printCallOp(CppEmitter &emitter, mlir::CallOp callOp) {
   if (failed(emitter.emitAssignPrefix(*callOp.getOperation())))
     return failure();
@@ -513,6 +539,8 @@ static LogicalResult printOperation(CppEmitter &emitter, Operation &op) {
     return printForOp(emitter, forOp);
   if (auto constantOp = dyn_cast<ConstantOp>(op))
     return printConstantOp(emitter, constantOp);
+  if (auto constOp = dyn_cast<emitc::ConstOp>(op))
+    return printConstOp(emitter, constOp);
   if (auto returnOp = dyn_cast<ReturnOp>(op))
     return printReturnOp(emitter, returnOp);
   if (auto moduleOp = dyn_cast<ModuleOp>(op))

--- a/test/Dialect/EmitC/ops.mlir
+++ b/test/Dialect/EmitC/ops.mlir
@@ -9,3 +9,8 @@ func @f(%arg0: i32, %f: !custom<"int32_t">) -> i1 {
   %2:3 = "bar"(%1) : (i64) -> (i1,i1,i1)
   return %2#1 : i1
 }
+
+func @c(%arg0: i32) {
+  %1 = "emitc.const"(){value = 42 : i32} : () -> i32
+  return
+}

--- a/test/Target/cpp-calls.mlir
+++ b/test/Target/cpp-calls.mlir
@@ -87,3 +87,11 @@ func @get_address_of(%arg0: i32) -> !emitc.opaque<"int32_t*"> {
   %0 = "emitc.getaddressof" (%arg0) : (i32) -> !emitc.opaque<"int32_t*">
   return %0 : !emitc.opaque<"int32_t*">
 }
+
+func @emitc_constant() {
+  // CHECK: int32_t [[V1]]{42};
+  %1 = "emitc.const"(){value = 42 : i32} : () -> i32
+  // CHECK: int32_t* [[V2]] = nullptr;
+  %2 = "emitc.const"(){value = "nullptr" : !emitc.opaque<"..">} : () -> !emitc.opaque<"int32_t*">
+  return
+}


### PR DESCRIPTION
Our constant operation is intended to support opaque attributes as well
as our opaque type.