### PR TITLE
Add conversion for tosa.matmul

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -18,3 +18,4 @@ The table below shows the supported TOSA ops.
 | mul                   | :heavy_check_mark: | |
 | **Other ops**
 | fully_connected       | :white_check_mark: | Quantization not supported |
+| matmul                | :white_check_mark: | Quantization not supported |

--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -166,6 +166,26 @@ broadcast_in_dim(Src operand,
   return result;
 }
 
+// DotOp
+template <typename Dest, typename Lhs, typename Rhs>
+Dest dot(Lhs lhs, Rhs rhs) {
+  static_assert(is_tensor_of_dim<2, Lhs>::value, "Expected 2 dimensional lhs");
+  static_assert(is_tensor_of_dim<2, Rhs>::value, "Expected 2 dimensional rhs");
+  static_assert(Lhs::dim(1) == Rhs::dim(0),
+                "Expected contracting dimension to match");
+  Dest output;
+
+  for (size_t m = 0; m < lhs.dim(0); m++) {
+    for (size_t n = 0; n < lhs.dim(1); n++) {
+      for (size_t k = 0; k < rhs.dim(1); k++) {
+        output(m, k) += lhs(m, n) * rhs(n, k);
+      }
+    }
+  }
+
+  return output;
+}
+
 } // namespace emitc
 
 #endif // EMITC_EMITC_CORE_OPS_H

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -1020,21 +1020,7 @@ Dest convolution(Src input, Weights weights, int64_t batch_group_count,
 // DotOp
 template <typename Dest, typename Lhs, typename Rhs>
 Dest dot(Lhs lhs, Rhs rhs) {
-  static_assert(is_tensor_of_dim<2, Lhs>::value, "Expected 2 dimensional lhs");
-  static_assert(is_tensor_of_dim<2, Rhs>::value, "Expected 2 dimensional rhs");
-  static_assert(Lhs::dim(1) == Rhs::dim(0),
-                "Expected contracting dimension to match");
-  Dest output;
-
-  for (size_t m = 0; m < lhs.dim(0); m++) {
-    for (size_t n = 0; n < lhs.dim(1); n++) {
-      for (size_t k = 0; k < rhs.dim(1); k++) {
-        output(m, k) += lhs(m, n) * rhs(n, k);
-      }
-    }
-  }
-
-  return output;
+  return emitc::dot<Dest>(lhs, rhs);
 }
 
 } // namespace mhlo

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -137,6 +137,12 @@ Dest fully_connected(Src input, Weights weights, Bias bias) {
   return output;
 }
 
+// MatMulOp
+template <typename T, size_t M, size_t K, size_t N>
+Tensor2D<T, M, N> matmul(Tensor2D<T, M, K> a, Tensor2D<T, K, N> b) {
+  return emitc::dot<Tensor2D<T, M, N>>(a, b);
+}
+
 } // namespace tosa
 
 #endif // EMITC_EMITC_TOSA_H

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -121,7 +121,7 @@ class MatMulOpConversion : public OpConversionPattern<tosa::MatMulOp> {
   using OpConversionPattern<tosa::MatMulOp>::OpConversionPattern;
 
 public:
-  MatMulOpConversion(MLIRContext *ctx, StringRef funcName)
+  MatMulOpConversion(MLIRContext *ctx)
       : OpConversionPattern<tosa::MatMulOp>(ctx) {}
 
 private:
@@ -141,7 +141,7 @@ private:
     ArrayAttr args;
     ArrayAttr templateArgs;
 
-    rewriter.replaceOpWithNewOp<emitc::CallOp>(matMulOp, type, callee, args,
+    rewriter.replaceOpWithNewOp<emitc::CallOp>(matMulOp, matMulOp.getType(), callee, args,
                                                templateArgs, operands);
     return success();
   }
@@ -352,7 +352,7 @@ void populateTosaToEmitcPatterns(MLIRContext *ctx,
 
   // Other ops
   patterns.insert<FullyConnectedOpConversion>(ctx, "tosa::fully_connected");
-  patterns.insert<MatMulOpConversion>(ctx, "tosa::matmul");
+  patterns.insert<MatMulOpConversion>(ctx);
 }
 
 namespace {

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -141,8 +141,8 @@ private:
     ArrayAttr args;
     ArrayAttr templateArgs;
 
-    rewriter.replaceOpWithNewOp<emitc::CallOp>(matMulOp, matMulOp.getType(), callee, args,
-                                               templateArgs, operands);
+    rewriter.replaceOpWithNewOp<emitc::CallOp>(
+        matMulOp, matMulOp.getType(), callee, args, templateArgs, operands);
     return success();
   }
 };

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -114,3 +114,11 @@ func @test_fully_connected(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>, %
   %0 = "tosa.fully_connected"(%arg0, %arg1, %arg2) : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   return %0 : tensor<14x28xf32>
 }
+
+
+// MatMulOp
+func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<14x28xf32> {
+  // CHECK: emitc.call "tosa::matmul"(%arg0, %arg1) : (tensor<14x19xf32>, tensor<19x28xf32>) -> tensor<14x28xf32>
+  %0 = "tosa.matmul"(%arg0, %arg1) : (tensor<14x19xf32>, tensor<19x28xf32>) -> tensor<14x28xf32>
+  return %0 : tensor<14x28xf32>
+}

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -89,7 +89,7 @@ TEST(tosa, matmul) {
     AType a{1, 2, 3};
     BType b{1, 2};
     CType c = tosa::matmul(a, b);
-    
+
     CType expected_result{1, 2, 2, 4, 3, 6};
     EXPECT_THAT(c, Pointwise(FloatNear(EPSILON), expected_result));
   }
@@ -100,7 +100,7 @@ TEST(tosa, matmul) {
     AType a{1, 2, 3, 4, 5, 6};
     BType b{7, 8, 9, 10};
     CType c = tosa::matmul(a, b);
-    
+
     CType expected_result{25, 28, 57, 64, 89, 100};
     EXPECT_THAT(c, Pointwise(FloatNear(EPSILON), expected_result));
   }

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -81,4 +81,29 @@ TEST(tosa, fully_connected) {
   EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
 }
 
+TEST(tosa, matmul) {
+  {
+    using AType = Tensor2D<float, 3, 1>; // M K
+    using BType = Tensor2D<float, 1, 2>; // K N
+    using CType = Tensor2D<float, 3, 2>; // M N
+    AType a{1, 2, 3};
+    BType b{1, 2};
+    CType c = tosa::matmul(a, b);
+    
+    CType expected_result{1, 2, 2, 4, 3, 6};
+    EXPECT_THAT(c, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+  {
+    using AType = Tensor2D<float, 3, 2>; // M K
+    using BType = Tensor2D<float, 2, 2>; // K N
+    using CType = Tensor2D<float, 3, 2>; // M N
+    AType a{1, 2, 3, 4, 5, 6};
+    BType b{7, 8, 9, 10};
+    CType c = tosa::matmul(a, b);
+    
+    CType expected_result{25, 28, 57, 64, 89, 100};
+    EXPECT_THAT(c, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+}
+
 } // namespace


### PR DESCRIPTION
This will also move the mhlo.dot op implementation to the emitc core ops, since we can reuse the implementation for the tosa.matmul op.