### PR TITLE
Add unittests for strided Conv2d

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -20,7 +20,7 @@ The table below shows the supported TOSA ops.
 | mul                   | :heavy_check_mark: | |
 | sub                   | :heavy_check_mark: | |
 | **Other ops**
-| conv2d                | :white_check_mark: | Quantization, dilation and strides not supported |
+| conv2d                | :white_check_mark: | Quantization and dilation not supported |
 | fully_connected       | :white_check_mark: | Quantization not supported |
 | matmul                | :white_check_mark: | Quantization not supported |
 | reduce_all            | :heavy_check_mark: | |

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -946,6 +946,9 @@ Dest convolution(Src input, Weights weights, int64_t batch_group_count,
   assert(weights.dim(kernel_input_feature_dimension) ==
          input.dim(input_feature_dimension) / feature_group_count);
 
+  assert(window_strides[0] > 0);
+  assert(window_strides[1] > 0);
+
   assert(lhs_dilation[0] == 1);
   assert(lhs_dilation[0] == 1);
 

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -120,6 +120,9 @@ Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
   static_assert(is_tensor_of_dim<4, Weights>::value,
                 "Expected 4 dimensional weights");
 
+  assert(stride[0] > 0);
+  assert(stride[1] > 0);
+
   assert(dilation[0] == 1);
   assert(dilation[1] == 1);
 

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -120,9 +120,6 @@ Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
   static_assert(is_tensor_of_dim<4, Weights>::value,
                 "Expected 4 dimensional weights");
 
-  assert(stride[0] == 1);
-  assert(stride[1] == 1);
-
   assert(dilation[0] == 1);
   assert(dilation[1] == 1);
 

--- a/unittests/emitc_mhlo.cpp
+++ b/unittests/emitc_mhlo.cpp
@@ -1282,7 +1282,7 @@ TEST(mhlo, convolution) {
 
     EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
   }
-  { 
+  {
     // Strided convolution
     using InputType = Tensor4D<float, 1, 4, 4, 1>;  // N H W C
     using WeightType = Tensor4D<float, 2, 2, 1, 1>; // KH KW CIN COUT

--- a/unittests/emitc_mhlo.cpp
+++ b/unittests/emitc_mhlo.cpp
@@ -1241,20 +1241,7 @@ TEST(mhlo, concatenate) {
                                     13.0f, 14.0f, 15.0f, 16.0f, 39.0f, 40.0f}));
 }
 
-/// Adapted from
-/// https://github.com/google/iree/blob/efd78a0b47a46457a644f43d98617d3e279b2a79/iree/test/e2e/xla_ops/convolution.mlir#L33
 TEST(mhlo, convolution) {
-  using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
-  using WeightType = Tensor4D<float, 3, 2, 2, 1>; // KH KW CIN COUT
-  using ResultType = Tensor4D<float, 1, 4, 5, 1>; // N H W C
-  InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
-                  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-                  29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
-  WeightType weights{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-  ResultType expected_result{600,  736,  872,  1008, 476,  1310, 1466,
-                             1622, 1778, 805,  2090, 2246, 2402, 2558,
-                             1135, 1080, 1152, 1224, 1296, 524};
-
   int64_t batch_group_count = 1;
   int64_t input_batch_dimension = 0;
   int64_t input_feature_dimension = 3;
@@ -1266,20 +1253,64 @@ TEST(mhlo, convolution) {
   int64_t output_feature_dimension = 3;
   Tensor1D<int64_t, 2> output_spatial_dimensions{1, 2};
   int64_t feature_group_count = 1;
-  Tensor2D<int64_t, 2, 2> padding{1, 1, 0, 1}; // {pt, pb, pl, pr}
   Tensor1D<int64_t, 2> rhs_dilation{1, 1};
   Tensor1D<int64_t, 2> lhs_dilation{1, 1};
-  Tensor1D<int64_t, 2> window_strides{1, 1};
+  {
+    /// Adapted from
+    /// https://github.com/google/iree/blob/efd78a0b47a46457a644f43d98617d3e279b2a79/iree/test/e2e/xla_ops/convolution.mlir#L33
+    using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
+    using WeightType = Tensor4D<float, 3, 2, 2, 1>; // KH KW CIN COUT
+    using ResultType = Tensor4D<float, 1, 4, 5, 1>; // N H W C
+    InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+                    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
+    WeightType weights{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    ResultType expected_result{600,  736,  872,  1008, 476,  1310, 1466,
+                               1622, 1778, 805,  2090, 2246, 2402, 2558,
+                               1135, 1080, 1152, 1224, 1296, 524};
 
-  ResultType result = mhlo::convolution<ResultType, InputType, WeightType>(
-      input, weights, batch_group_count, input_batch_dimension,
-      input_feature_dimension, input_spatial_dimensions,
-      kernel_input_feature_dimension, kernel_output_feature_dimension,
-      kernel_spatial_dimensions, output_batch_dimension,
-      output_feature_dimension, output_spatial_dimensions, feature_group_count,
-      padding, lhs_dilation, rhs_dilation, window_strides);
+    Tensor2D<int64_t, 2, 2> padding{1, 1, 0, 1}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> window_strides{1, 1};
+    ResultType result = mhlo::convolution<ResultType, InputType, WeightType>(
+        input, weights, batch_group_count, input_batch_dimension,
+        input_feature_dimension, input_spatial_dimensions,
+        kernel_input_feature_dimension, kernel_output_feature_dimension,
+        kernel_spatial_dimensions, output_batch_dimension,
+        output_feature_dimension, output_spatial_dimensions,
+        feature_group_count, padding, lhs_dilation, rhs_dilation,
+        window_strides);
 
-  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+  { 
+    // Strided convolution
+    using InputType = Tensor4D<float, 1, 4, 4, 1>;  // N H W C
+    using WeightType = Tensor4D<float, 2, 2, 1, 1>; // KH KW CIN COUT
+    using ResultType = Tensor4D<float, 1, 2, 2, 1>; // N H W C
+    // clang-format off
+    InputType input{1,  2,  3,  4,
+                    5,  6,  7,  8,
+                    9,  10, 11, 12,
+                    13, 14, 15, 16};
+    WeightType weights{1, 2,
+                       3, 4};
+    ResultType expected_result{44,  64,
+                              124, 144};
+    // clang-format on
+
+    Tensor2D<int64_t, 2, 2> padding{0, 0, 0, 0}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> window_strides{2, 2};
+    ResultType result = mhlo::convolution<ResultType, InputType, WeightType>(
+        input, weights, batch_group_count, input_batch_dimension,
+        input_feature_dimension, input_spatial_dimensions,
+        kernel_input_feature_dimension, kernel_output_feature_dimension,
+        kernel_spatial_dimensions, output_batch_dimension,
+        output_feature_dimension, output_spatial_dimensions,
+        feature_group_count, padding, lhs_dilation, rhs_dilation,
+        window_strides);
+
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
 }
 
 TEST(mhlo, convolution_depthwise) {

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -68,7 +68,8 @@ TEST(tosa, mul) {
 
 // Other ops
 TEST(tosa, conv2d) {
-  { // strides = 1
+  {
+    // strides = 1
     using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
     using WeightType = Tensor4D<float, 1, 3, 2, 2>; // COUT KH KW CIN
     using ResultType = Tensor4D<float, 1, 4, 5, 1>; // N H W C
@@ -88,7 +89,7 @@ TEST(tosa, conv2d) {
         tosa::conv2d<ResultType>(input, weights, padding, stride, dilation);
     EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
   }
-  { 
+  {
     // Strided convolution
     using InputType = Tensor4D<float, 1, 4, 4, 1>;  // N H W C
     using WeightType = Tensor4D<float, 1, 2, 2, 1>; // COUT KH KW CIN

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -68,24 +68,49 @@ TEST(tosa, mul) {
 
 // Other ops
 TEST(tosa, conv2d) {
-  using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
-  using WeightType = Tensor4D<float, 1, 3, 2, 2>; // COUT KH KW CIN
-  using ResultType = Tensor4D<float, 1, 4, 5, 1>; // N H W C
-  InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
-                  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-                  29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
-  WeightType weights{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-  ResultType expected_result{600,  736,  872,  1008, 476,  1310, 1466,
-                             1622, 1778, 805,  2090, 2246, 2402, 2558,
-                             1135, 1080, 1152, 1224, 1296, 524};
+  { // strides = 1
+    using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
+    using WeightType = Tensor4D<float, 1, 3, 2, 2>; // COUT KH KW CIN
+    using ResultType = Tensor4D<float, 1, 4, 5, 1>; // N H W C
+    InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+                    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
+    WeightType weights{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    ResultType expected_result{600,  736,  872,  1008, 476,  1310, 1466,
+                               1622, 1778, 805,  2090, 2246, 2402, 2558,
+                               1135, 1080, 1152, 1224, 1296, 524};
 
-  Tensor1D<int64_t, 4> padding{1, 1, 0, 1}; // {pt, pb, pl, pr}
-  Tensor1D<int64_t, 2> dilation{1, 1};
-  Tensor1D<int64_t, 2> stride{1, 1};
+    Tensor1D<int64_t, 4> padding{1, 1, 0, 1}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> dilation{1, 1};
+    Tensor1D<int64_t, 2> stride{1, 1};
 
-  ResultType result =
-      tosa::conv2d<ResultType>(input, weights, padding, stride, dilation);
-  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+    ResultType result =
+        tosa::conv2d<ResultType>(input, weights, padding, stride, dilation);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+  { 
+    // Strided convolution
+    using InputType = Tensor4D<float, 1, 4, 4, 1>;  // N H W C
+    using WeightType = Tensor4D<float, 1, 2, 2, 1>; // COUT KH KW CIN
+    using ResultType = Tensor4D<float, 1, 2, 2, 1>; // N H W C
+    // clang-format off
+    InputType input{1,  2,  3,  4,
+                    5,  6,  7,  8,
+                    9,  10, 11, 12,
+                    13, 14, 15, 16};
+    WeightType weights{1, 2,
+                       3, 4};
+    ResultType expected_result{44,  64,
+                              124, 144};
+    // clang-format on
+    Tensor1D<int64_t, 4> padding{0, 0, 0, 1}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> dilation{1, 1};
+    Tensor1D<int64_t, 2> stride{2, 2};
+
+    ResultType result =
+        tosa::conv2d<ResultType>(input, weights, padding, stride, dilation);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
 }
 
 TEST(tosa, fully_connected) {


### PR DESCRIPTION
This verifies that the TOSA and MHLO convolution implementation support strided convolutions by adding unittests. 