### PR TITLE
Create initial C target

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ The `emitc-opt` tool enables conversions via the following options:
 The currently supported MHLO ops are listed in the [docs/mhlo-op-coverage.md](docs/mhlo-op-coverage.md) document.
 Supported TOSA ops are listed in the [docs/tosa-op-coverage.md](docs/tosa-op-coverage.md) document.
 
-After converting to EmitC, C++ code can be emited using `emitc-translate --mlir-to-cpp`.
+After converting to EmitC dialect, C++ code can be emitted using `emitc-translate --mlir-to-cpp`.
+For a restricted set of operations C code can be emitted using `emitc-translate --mlir-to-c`.

--- a/include/emitc/InitTranslation.h
+++ b/include/emitc/InitTranslation.h
@@ -17,6 +17,7 @@
 namespace mlir {
 
 void registerMlirToCppTranslation();
+void registerMlirToCTranslation();
 
 // This function should be called before creating any MLIRContext if one
 // expects all the possible translations to be made available to the context
@@ -24,6 +25,7 @@ void registerMlirToCppTranslation();
 inline void registerEmitCTranslation() {
   static bool init_once = []() {
     registerMlirToCppTranslation();
+    registerMlirToCTranslation();
     return true;
   }();
   (void)init_once;

--- a/include/emitc/Target/Cpp.h
+++ b/include/emitc/Target/Cpp.h
@@ -59,7 +59,7 @@ inline LogicalResult interleaveCommaWithError(const Container &c,
 
 /// Emitter that uses dialect specific emitters to emit C++ code.
 struct CppEmitter {
-  explicit CppEmitter(raw_ostream &os);
+  explicit CppEmitter(raw_ostream &os, bool restrictToC);
 
   /// Emits attribute or returns failure.
   LogicalResult emitAttribute(Attribute attr);
@@ -99,7 +99,7 @@ struct CppEmitter {
   /// Return the existing or a new name for a Value.
   StringRef getOrCreateName(Value val);
 
-  /// Whether to map an mlir integer to a signed integer in C++
+  /// Whether to map an mlir integer to a signed integer in C++.
   bool mapToSigned(IntegerType::SignednessSemantics val);
 
   /// RAII helper function to manage entering/exiting C++ scopes.
@@ -120,11 +120,17 @@ struct CppEmitter {
   /// Returns the output stream.
   raw_ostream &ostream() { return os; };
 
+  /// Returns if to emitc C.
+  bool restrictedToC() { return restrictToC; };
+
 private:
   using ValMapper = llvm::ScopedHashTable<Value, std::string>;
 
   /// Output stream to emit to.
   raw_ostream &os;
+
+  /// Boolean that restricts the emitter to C.
+  bool restrictToC;
 
   /// Map from value to name of C++ variable that contain the name.
   ValMapper mapper;
@@ -139,6 +145,9 @@ private:
 LogicalResult TranslateToCpp(Operation &op, raw_ostream &os,
                              bool trailingSemicolon = false);
 
+/// Similar to `TranslateToCpp`, but translates the given operation to C code.
+LogicalResult TranslateToC(Operation &op, raw_ostream &os,
+                           bool trailingSemicolon = false);
 } // namespace emitc
 } // namespace mlir
 

--- a/lib/Target/CMakeLists.txt
+++ b/lib/Target/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(MLIRTargetCpp
   Cpp/TranslateToCpp.cpp
   Cpp/TranslateToCppRegistration.cpp
+  Cpp/TranslateToCRegistration.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/emitc/Target/Cpp

--- a/lib/Target/Cpp/TranslateToCRegistration.cpp
+++ b/lib/Target/Cpp/TranslateToCRegistration.cpp
@@ -1,4 +1,4 @@
-//===- TranslateToCppRegistration.cpp - Register translation ------ C++ -*-===//
+//===- TranslateToCRegistration.cpp - Register translation -------- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,16 +15,16 @@
 
 using namespace mlir;
 
-static LogicalResult MlirToCppTranslateFunction(ModuleOp module,
-                                                llvm::raw_ostream &output) {
-  return emitc::TranslateToCpp(*module.getOperation(), output,
-                               /*trailingSemiColon=*/false);
+static LogicalResult MlirToCTranslateFunction(ModuleOp module,
+                                              llvm::raw_ostream &output) {
+  return emitc::TranslateToC(*module.getOperation(), output,
+                             /*trailingSemiColon=*/false);
 }
 
 namespace mlir {
-void registerMlirToCppTranslation() {
+void registerMlirToCTranslation() {
   TranslateFromMLIRRegistration reg(
-      "mlir-to-cpp", MlirToCppTranslateFunction, [](DialectRegistry &registry) {
+      "mlir-to-c", MlirToCTranslateFunction, [](DialectRegistry &registry) {
         registry.insert<emitc::EmitCDialect, StandardOpsDialect>();
       });
 }

--- a/test/Target/c-calls.mlir
+++ b/test/Target/c-calls.mlir
@@ -1,0 +1,13 @@
+// RUN: emitc-translate -mlir-to-c %s | FileCheck %s
+
+// CHECK: // Forward declare functions.
+// CHECK: void emitc_constant();
+
+// CHECK: void emitc_constant()
+func @emitc_constant() {
+  // CHECK: int32_t [[V1:[^ ]*]] = 42;
+  %1 = "emitc.const"(){value = 42 : i32} : () -> i32
+  // CHECK: int32_t* [[V2:[^ ]*]] = nullptr;
+  %2 = "emitc.const"(){value = "nullptr" : !emitc.opaque<"..">} : () -> !emitc.opaque<"int32_t*">
+  return
+}

--- a/test/Target/c-calls.mlir
+++ b/test/Target/c-calls.mlir
@@ -7,7 +7,7 @@
 func @emitc_constant() {
   // CHECK: int32_t [[V1:[^ ]*]] = 42;
   %1 = "emitc.const"(){value = 42 : i32} : () -> i32
-  // CHECK: int32_t* [[V2:[^ ]*]] = nullptr;
-  %2 = "emitc.const"(){value = "nullptr" : !emitc.opaque<"..">} : () -> !emitc.opaque<"int32_t*">
+  // CHECK: int32_t* [[V2:[^ ]*]] = NULL;
+  %2 = "emitc.const"(){value = "NULL" : !emitc.opaque<"..">} : () -> !emitc.opaque<"int32_t*">
   return
 }


### PR DESCRIPTION
The C target is a special form of C++ target, which supports emitting C
code for a limited subset of operations and types. For example the C
target does not support tensors or multiple return values. Furthermore,
assignments use = and never the curly-brace-delimited initializer which
is used in the C++ target.