### PR TITLE
Change tosa::conv2d attributes type to dense

### DIFF
--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -25,7 +25,7 @@ namespace emitc {
 namespace {
 
 // Common functions
-DenseIntElementsAttr GetI64ElementsAttr(const ArrayAttr values,
+DenseIntElementsAttr getI64ElementsAttr(const ArrayAttr values,
                                         MLIRContext *ctx) {
   RankedTensorType ty = RankedTensorType::get(
       {static_cast<int64_t>(values.size())}, IntegerType::get(ctx, 64));
@@ -138,9 +138,9 @@ private:
     ArrayAttr args = rewriter.getArrayAttr({
       rewriter.getIndexAttr(0),
       rewriter.getIndexAttr(1),
-      GetI64ElementsAttr(conv2dOp.pad(), conv2dOp.getContext()),
-      GetI64ElementsAttr(conv2dOp.stride(), conv2dOp.getContext()),
-      GetI64ElementsAttr(conv2dOp.dilation(), conv2dOp.getContext()),
+      getI64ElementsAttr(conv2dOp.pad(), conv2dOp.getContext()),
+      getI64ElementsAttr(conv2dOp.stride(), conv2dOp.getContext()),
+      getI64ElementsAttr(conv2dOp.dilation(), conv2dOp.getContext()),
     });
     // clang-format on
 

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -24,6 +24,23 @@ namespace emitc {
 
 namespace {
 
+// Common functions
+DenseIntElementsAttr GetI64ElementsAttr(const ArrayAttr values,
+                                        MLIRContext *ctx) {
+  RankedTensorType ty = RankedTensorType::get(
+      {static_cast<int64_t>(values.size())}, IntegerType::get(ctx, 64));
+
+  SmallVector<int64_t> valuesAsI64;
+
+  // convert values to int64_t
+  for (auto &value : values) {
+    auto valueAsIntAttr = value.cast<IntegerAttr>();
+    valuesAsI64.push_back(valueAsIntAttr.getInt());
+  };
+
+  return DenseIntElementsAttr::get(ty, valuesAsI64);
+}
+
 SmallVector<Attribute, 2> indexSequence(int64_t n, MLIRContext *ctx) {
   return llvm::to_vector<2>(
       llvm::map_range(llvm::seq<int64_t>(0, n), [&ctx](int64_t i) -> Attribute {
@@ -121,9 +138,9 @@ private:
     ArrayAttr args = rewriter.getArrayAttr({
       rewriter.getIndexAttr(0),
       rewriter.getIndexAttr(1),
-      conv2dOp.pad(),
-      conv2dOp.stride(),
-      conv2dOp.dilation()
+      GetI64ElementsAttr(conv2dOp.pad(), conv2dOp.getContext()),
+      GetI64ElementsAttr(conv2dOp.stride(), conv2dOp.getContext()),
+      GetI64ElementsAttr(conv2dOp.dilation(), conv2dOp.getContext()),
     });
     // clang-format on
 

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -126,7 +126,7 @@ func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor
 // Other ops
 
 func @test_conv2d(%arg0: tensor<1x4x4x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg2: tensor<8xf32>) -> tensor<1x4x4x8xf32> {
-    // CHECK: %0 = emitc.call "tosa::conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, [0, 0, 0, 0], [1, 1], [1, 1]], template_args = [tensor<1x4x4x8xf32>]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>) -> tensor<1x4x4x8xf32>
+    // CHECK: %0 = emitc.call "tosa::conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x4x4x8xf32>]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>) -> tensor<1x4x4x8xf32>
     // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [dense<3> : tensor<1xi64>], template_args = [tensor<1x4x4x8xf32>]} : (tensor<8xf32>) -> tensor<1x4x4x8xf32>
     // CHECK: %2 = emitc.call "tosa::add"(%0, %1) {template_args = []} : (tensor<1x4x4x8xf32>, tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
     %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x4x4x8xf32>


### PR DESCRIPTION
This changes the type of the attributes of the converted `tosa::conv2d` op to dense. This is mandatory for `emitc-translate --mlir-to-cpp`.