### PR TITLE
Introduce the `forwardDeclareVariables` flag

### DIFF
--- a/include/emitc/Target/Cpp.h
+++ b/include/emitc/Target/Cpp.h
@@ -59,7 +59,8 @@ inline LogicalResult interleaveCommaWithError(const Container &c,
 
 /// Emitter that uses dialect specific emitters to emit C++ code.
 struct CppEmitter {
-  explicit CppEmitter(raw_ostream &os, bool restrictToC);
+  explicit CppEmitter(raw_ostream &os, bool restrictToC,
+                      bool forwardDeclareVariables);
 
   /// Emits attribute or returns failure.
   LogicalResult emitAttribute(Attribute attr);
@@ -123,6 +124,9 @@ struct CppEmitter {
   /// Returns if to emitc C.
   bool restrictedToC() { return restrictToC; };
 
+  /// Returns if all variables need to be forward declared.
+  bool forwardDeclaredVariables() { return forwardDeclareVariables; };
+
 private:
   using ValMapper = llvm::ScopedHashTable<Value, std::string>;
 
@@ -131,6 +135,9 @@ private:
 
   /// Boolean that restricts the emitter to C.
   bool restrictToC;
+
+  /// Boolean to enforce a forward declaration of all variables.
+  bool forwardDeclareVariables;
 
   /// Map from value to name of C++ variable that contain the name.
   ValMapper mapper;

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -366,8 +366,10 @@ static LogicalResult printFunction(CppEmitter &emitter, FuncOp functionOp) {
   return success();
 }
 
-CppEmitter::CppEmitter(raw_ostream &os, bool restrictToC)
-    : os(os), restrictToC(restrictToC) {
+CppEmitter::CppEmitter(raw_ostream &os, bool restrictToC,
+                       bool forwardDeclareVariables)
+    : os(os), restrictToC(restrictToC),
+      forwardDeclareVariables(forwardDeclareVariables) {
   valueInScopeCount.push(0);
 }
 
@@ -677,12 +679,14 @@ LogicalResult CppEmitter::emitTupleType(ArrayRef<Type> types) {
 
 LogicalResult emitc::TranslateToCpp(Operation &op, raw_ostream &os,
                                     bool trailingSemicolon) {
-  CppEmitter emitter(os, false);
+  CppEmitter emitter(os, /*restrictToC=*/false,
+                     /*forwardDeclareVariables=*/false);
   return emitter.emitOperation(op, trailingSemicolon);
 }
 
 LogicalResult emitc::TranslateToC(Operation &op, raw_ostream &os,
                                   bool trailingSemicolon) {
-  CppEmitter emitter(os, true);
+  CppEmitter emitter(os, /*restrictToC=*/true,
+                     /*forwardDeclareVariables=*/false);
   return emitter.emitOperation(op, trailingSemicolon);
 }


### PR DESCRIPTION
Introduces a flag to enforce the the printer to forward declare all
emitted variables.