### PR TITLE
Add conversion for tosa.reluN

### DIFF
--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -80,6 +80,42 @@ inline Src log(Src x) {
   return unary<Src>(x, f);
 }
 
+// ReluNOp
+template <typename Min, typename Src, typename Max>
+inline Src clamp(Min min, Src operand, Max max) {
+  static_assert(
+      std::is_same<Min, Src>::value ||
+          (is_tensor_of_dim<0, Min>::value &&
+           std::is_same<typename get_element_type<Src>::type,
+                        typename get_element_type<Min>::type>::value),
+      "Expected the same type for min and operand or a 0-dim tensor of the "
+      "same element type for min");
+  static_assert(
+      std::is_same<Max, Src>::value ||
+          (is_tensor_of_dim<0, Max>::value &&
+           std::is_same<typename get_element_type<Src>::type,
+                        typename get_element_type<Min>::type>::value),
+      "Expected the same type for min and operand or a 0-dim tensor of the "
+      "same element type for max");
+
+  const bool broadcast_min = !std::is_same<Min, Src>::value;
+  const bool broadcast_max = !std::is_same<Max, Src>::value;
+
+  Src result;
+  for (size_t index = 0; index < Src::size(); index++) {
+    const auto value_min = broadcast_min ? min[0] : min[index];
+    const auto value_max = broadcast_max ? max[0] : max[index];
+
+    auto value = operand[index];
+    value = value < value_min ? value_min : value;
+    value = value > value_max ? value_max : value;
+
+    result[index] = value;
+  }
+
+  return result;
+}
+
 // SqrtOp
 template <typename Src>
 inline Src sqrt(Src x) {

--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -338,37 +338,7 @@ broadcast_in_dim(Src operand,
 // ClampOp
 template <typename Min, typename Src, typename Max>
 inline Src clamp(Min min, Src operand, Max max) {
-  static_assert(
-      std::is_same<Min, Src>::value ||
-          (is_tensor_of_dim<0, Min>::value &&
-           std::is_same<typename get_element_type<Src>::type,
-                        typename get_element_type<Min>::type>::value),
-      "Expected the same type for min and operand or a 0-dim tensor of the "
-      "same element type for min");
-  static_assert(
-      std::is_same<Max, Src>::value ||
-          (is_tensor_of_dim<0, Max>::value &&
-           std::is_same<typename get_element_type<Src>::type,
-                        typename get_element_type<Min>::type>::value),
-      "Expected the same type for min and operand or a 0-dim tensor of the "
-      "same element type for max");
-
-  const bool broadcast_min = !std::is_same<Min, Src>::value;
-  const bool broadcast_max = !std::is_same<Max, Src>::value;
-
-  Src result;
-  for (size_t index = 0; index < Src::size(); index++) {
-    const auto value_min = broadcast_min ? min[0] : min[index];
-    const auto value_max = broadcast_max ? max[0] : max[index];
-
-    auto value = operand[index];
-    value = value < value_min ? value_min : value;
-    value = value > value_max ? value_max : value;
-
-    result[index] = value;
-  }
-
-  return result;
+  return emitc::clamp(min, operand, max);
 }
 
 // ConcatenateOp

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -62,6 +62,14 @@ inline Src reciprocal(Src x) {
   return unary<Src>(x, f);
 }
 
+// ReluNOp
+template <typename Src, typename Limit>
+inline Src reluN(Src operand, Limit max_value) {
+  Tensor0D<Limit> min{0};
+  Tensor0D<Limit> max{max_value};
+  return emitc::clamp(min, operand, max);
+}
+
 // TanhOp
 template <typename Src>
 inline Src tanh(Src x) {

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -241,7 +241,8 @@ private:
     SmallVector<Attribute, 2> args_;
     args_.push_back(rewriter.getIndexAttr(0));
 
-    // Determine to which max value we have to clamp to
+    // Since tosa.reluN has two max attribute types for float and integer
+    // values, we have to determine to which max attribute we have to clamp to
     auto operandType =
         operands[0].getType().cast<RankedTensorType>().getElementType();
     if (operandType.isSignedInteger() || operandType.isSignlessInteger() ||

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -243,14 +243,11 @@ private:
 
     // Since tosa.reluN has two max attribute types for float and integer
     // values, we have to determine to which max attribute we have to clamp to
-    auto operandType =
+    auto elementType =
         operands[0].getType().cast<RankedTensorType>().getElementType();
-    if (operandType.isSignedInteger() || operandType.isSignlessInteger() ||
-        operandType.isUnsignedInteger()) {
+    if (elementType.isa<IntegerType>()) {
       args_.push_back(reluNOp.max_intAttr());
-    } else if (operandType.isF16() || operandType.isF32() ||
-               operandType.isF64() || operandType.isF80() ||
-               operandType.isF128()) {
+    } else if (elementType.isa<FloatType>()) {
       args_.push_back(reluNOp.max_fpAttr());
     } else {
       return reluNOp.emitError(

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -193,3 +193,15 @@ func @test_reshape(%arg0: tensor<13x21x3xf32>) -> tensor<1x819xf32> {
   %0 = "tosa.reshape"(%arg0) {new_shape = [1, 819]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>
   return %0 : tensor<1x819xf32>
 }
+
+func @test_relu0(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
+  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 3.40282347E+38 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  %0 = "tosa.reluN"(%arg0) {max_fp = 3.40282347E+38 : f32, max_int = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  return %0 : tensor<13x21x3xf32>
+}
+
+func @test_relu1(%arg0: tensor<13x21x3xi64>) -> tensor<13x21x3xi64> {
+  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 255]} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
+  %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
+  return %0 : tensor<13x21x3xi64>
+}

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -34,6 +34,26 @@ TEST(tosa, reciprocal) {
   EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected));
 }
 
+TEST(tosa, reluN) {
+  Tensor<float, 2, 1> t0{0.0f, 5.0f};
+  float max0 = 3.0f;
+  Tensor<float, 2, 1> expected_result0{0.0, 3.0f};
+  Tensor<float, 2, 1> s0 = tosa::reluN(t0, max0);
+
+  EXPECT_THAT(s0, Pointwise(FloatEq(), expected_result0));
+
+  Tensor<int64_t, 4, 2, 1> t1{-2, 2, -2, 3, 4, -5, 5, 5};
+  int64_t max1 = 3;
+  Tensor<int64_t, 4, 2, 1> expected_result1{0, 2, 0, 3, 3, 0, 3, 3};
+  Tensor<int64_t, 4, 2, 1> s1 = tosa::reluN(t1, max1);
+  EXPECT_THAT(s1, Pointwise(Eq(), expected_result1));
+
+  int64_t max2 = 100;
+  Tensor<int64_t, 4, 2, 1> expected_result2{0, 2, 0, 3, 4, 0, 5, 5};
+  Tensor<int64_t, 4, 2, 1> s2 = tosa::reluN(t1, max2);
+  EXPECT_THAT(s2, Pointwise(Eq(), expected_result2));
+}
+
 // Binary elementwise ops
 TEST(tosa, mul) {
   // no shift


### PR DESCRIPTION
This also moves the mhlo.clamp op implementation to the emitc core ops, so that we can reuse the implementation for tosa.reluN.