### PR TITLE
Add conversion for tosa.depthwise_conv2d 

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -21,6 +21,7 @@ The table below shows the supported TOSA ops.
 | sub                   | :heavy_check_mark: | |
 | **Other ops**
 | conv2d                | :white_check_mark: | Quantization and dilation not supported |
+| depthwise_conv2d      | :white_check_mark: | Quantization and dilation not supported |
 | fully_connected       | :white_check_mark: | Quantization not supported |
 | matmul                | :white_check_mark: | Quantization not supported |
 | reduce_all            | :heavy_check_mark: | |

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -191,9 +191,16 @@ Dest depthwise_conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
                 "Expected 4 dimensional output");
   static_assert(is_tensor_of_dim<4, Weights>::value,
                 "Expected 4 dimensional weights");
+
+  // Check dimensions
+  static_assert(Src::dim(3) == Weights::dim(2),
+                "Input channels must equal weights channels");
   static_assert(Src::dim(0) == Dest::dim(0), "Batch sizes must be equal");
   static_assert(Dest::dim(3) % Src::dim(3) == 0,
                 "Output channels need to be a multiple of input channels");
+  static_assert(
+      Dest::dim(3) == Src::dim(3) * Weights::dim(3),
+      "Output channels size must be input channels times channel multiplier");
 
   assert(stride[0] > 0);
   assert(stride[1] > 0);
@@ -208,11 +215,9 @@ Dest depthwise_conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
 
   Dest output;
 
-  const int CxM = output.dim(3);
-  const int M = CxM / C_IN;
-
   const int K_H = weights.dim(0);
   const int K_W = weights.dim(1);
+  const int M = weights.dim(3);
 
   const int S_H = stride[0];
   const int S_W = stride[1];

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -178,6 +178,91 @@ Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
   return output;
 }
 
+// DepthwiseConv2DOp
+template <typename Dest, typename Src, typename Weights>
+Dest depthwise_conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
+                      Tensor1D<int64_t, 2> stride,
+                      Tensor1D<int64_t, 2> dilation) {
+  // Input is [N,IH,IW,IC], weights
+  // are [KH,KW,CIN,M] and output is [N,H,W,C*M].
+  static_assert(is_tensor_of_dim<4, Src>::value,
+                "Expected 4 dimensional input");
+  static_assert(is_tensor_of_dim<4, Dest>::value,
+                "Expected 4 dimensional output");
+  static_assert(is_tensor_of_dim<4, Weights>::value,
+                "Expected 4 dimensional weights");
+
+  assert(stride[0] > 0);
+  assert(stride[1] > 0);
+
+  assert(dilation[0] == 1);
+  assert(dilation[1] == 1);
+
+  const int N = input.dim(0);
+  const int H_IN = input.dim(1);
+  const int W_IN = input.dim(2);
+
+  const int feature_group_count = input.dim(3);
+
+  Dest output;
+
+  const int C_OUT = output.dim(3);
+  assert(C_OUT % feature_group_count == 0);
+  const int G_OUT = C_OUT / feature_group_count;
+
+  const int K_H = weights.dim(0);
+  const int K_W = weights.dim(1);
+
+  const int S_H = stride[0];
+  const int S_W = stride[1];
+
+  const int pt = padding[0];
+  const int pb = padding[1];
+  const int pl = padding[2];
+  const int pr = padding[3];
+
+  const int H_PAD = pt + H_IN + pb;
+  const int W_PAD = pl + W_IN + pr;
+
+  // Convolution
+  for (int n = 0; n < N; ++n) {
+    for (int h_pad = 0; h_pad < H_PAD - K_H + 1; h_pad += S_H) {
+      for (int w_pad = 0; w_pad < W_PAD - K_W + 1; w_pad += S_W) {
+        for (int kh = 0; kh < K_H; ++kh) {
+          for (int kw = 0; kw < K_W; ++kw) {
+            for (int g = 0; g < feature_group_count; ++g) {
+              for (int g_out = 0; g_out < G_OUT; ++g_out) {
+                const int h_out = h_pad / S_H;
+                const int w_out = w_pad / S_W;
+                const int c_out = g * G_OUT + g_out;
+                const int h_in = h_pad - pt + kh;
+                const int w_in = w_pad - pl + kw;
+
+                if (h_in < 0 || h_in >= H_IN || w_in < 0 || w_in >= W_IN)
+                  continue;
+
+                // for depthwise convolution we interpret weights as a tensor
+                // with shape [filter_height, filter_width, 1, in_channels *
+                // channel_multiplier]. So we need to calculate the index
+                // using these dimensions.
+                const int weights_index =
+                    ravel_index<Weights::dim(0), Weights::dim(1), 1,
+                                Weights::dim(2) * Weights::dim(3)>(kh, kw, 0,
+                                                                   c_out);
+
+                output(n, h_out, w_out, c_out) +=
+                    input(n, h_in, w_in, g) * weights[weights_index];
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return output;
+}
+
 // FullyConnectedOp
 template <typename Dest, typename Src, typename Weights, typename Bias>
 Dest fully_connected(Src input, Weights weights, Bias bias) {

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -245,10 +245,9 @@ Dest depthwise_conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
                 // with shape [filter_height, filter_width, 1, in_channels *
                 // channel_multiplier]. So we need to calculate the index
                 // using these dimensions.
-                const int weights_index =
-                    ravel_index<Weights::dim(0), Weights::dim(1), 1,
-                                Weights::dim(2) * Weights::dim(3)>(kh, kw, 0,
-                                                                   c_out);
+                const size_t weights_index = emitc::utility::ravel_index<
+                    Weights::dim(0), Weights::dim(1), 1,
+                    Weights::dim(2) * Weights::dim(3)>(kh, kw, 0, c_out);
 
                 output(n, h_out, w_out, c_out) +=
                     input(n, h_in, w_in, g) * weights[weights_index];

--- a/include/emitc/emitc_types.h
+++ b/include/emitc/emitc_types.h
@@ -22,7 +22,7 @@
 #include <numeric>
 #include <vector>
 
-#include "emitc/emitc_utility.h"
+#include "emitc_utility.h"
 
 namespace detail {
 template <size_t N>

--- a/include/emitc/emitc_utility.h
+++ b/include/emitc/emitc_utility.h
@@ -1,0 +1,93 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMITC_EMITC_UTILITIES_H
+#define EMITC_EMITC_UTILITIES_H
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+
+namespace emitc {
+namespace utility {
+template <size_t... Shape>
+static constexpr size_t size() {
+  constexpr std::array<size_t, sizeof...(Shape)> s = {Shape...};
+
+  size_t result = 1;
+  for (size_t i = 0; i < sizeof...(Shape); ++i) {
+    result *= s[i];
+  }
+  return result;
+}
+
+template <size_t... Shape>
+static constexpr std::array<size_t, sizeof...(Shape)> strides() {
+  std::array<size_t, sizeof...(Shape)> result = {};
+  constexpr std::array<size_t, sizeof...(Shape)> s = {Shape...};
+
+  if (sizeof...(Shape) == 0) {
+    return result;
+  }
+
+  result[sizeof...(Shape) - 1] = 1;
+
+  for (size_t i = sizeof...(Shape) - 1; i > 0; i--) {
+    result[i - 1] = result[i] * s[i];
+  }
+
+  return result;
+}
+
+template <size_t... Shape>
+constexpr size_t ravel_index(std::array<size_t, sizeof...(Shape)> indices) {
+  std::array<size_t, sizeof...(Shape)> shape = {Shape...};
+
+  for (size_t i = 0; i < sizeof...(Shape); ++i) {
+    assert(indices[i] < shape[i]);
+  }
+
+  std::array<size_t, sizeof...(Shape)> s = strides<Shape...>();
+
+  size_t result = 0;
+  for (size_t i = 0; i < indices.size(); ++i) {
+    result += indices[i] * s[i];
+  }
+
+  return result;
+}
+
+template <size_t... Shape, typename... Indices>
+constexpr size_t ravel_index(Indices... indices) {
+  static_assert(sizeof...(Indices) == sizeof...(Shape),
+                "Incorrect number of arguments");
+  return ravel_index<Shape...>({static_cast<size_t>(indices)...});
+}
+
+template <size_t... Shape>
+constexpr std::array<size_t, sizeof...(Shape)> unravel_index(size_t index) {
+  assert(index < size<Shape...>());
+
+  std::array<size_t, sizeof...(Shape)> s = strides<Shape...>();
+
+  std::array<size_t, sizeof...(Shape)> result = {};
+  for (size_t i = 0; i < sizeof...(Shape); ++i) {
+    result[i] = index / s[i];
+    index = index % s[i];
+  }
+
+  return result;
+}
+
+} // namespace utility
+} // namespace emitc
+#endif // EMITC_EMITC_UTILITIES_H

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -109,26 +109,26 @@ public:
 };
 
 template <typename SrcOp>
-class Conv2DOpConversion : public OpConversionPattern<SrcOp> {
+class GenericConvOpConversion : public OpConversionPattern<SrcOp> {
   using OpConversionPattern<SrcOp>::OpConversionPattern;
 
 public:
-  Conv2DOpConversion(MLIRContext *ctx, StringRef funcName)
+  GenericConvOpConversion(MLIRContext *ctx, StringRef funcName)
       : OpConversionPattern<SrcOp>(ctx), funcName(funcName) {}
 
 private:
   LogicalResult
-  matchAndRewrite(SrcOp conv2dOp, ArrayRef<Value> operands,
+  matchAndRewrite(SrcOp convOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     // fail if quantization is requested
-    if (conv2dOp.quantization_info().hasValue()) {
-      return conv2dOp.emitError(
-          "Quantization of tosa.conv2d is currently not supported.");
+    if (convOp.quantization_info().hasValue()) {
+      return convOp.emitError("Quantization for " + convOp.getOperationName() +
+                              " is currently not supported.");
     }
 
-    // tosa conv2D supports adding a bias after the actual convolution. We will
-    // split the convolution with bias into two operations: the convolution (as
-    // an emitc call op) and the addition of the bias (as an tosa.add op).
+    // All tosa conv* ops support adding a bias after the actual convolution. We
+    // will split the convolution with bias into two operations: the convolution
+    // (as an emitc call op) and the addition of the bias (as an tosa.add op).
     // Therefore we remove bias from the operands of the convolution.
     operands = operands.drop_back();
 
@@ -138,25 +138,25 @@ private:
     ArrayAttr args = rewriter.getArrayAttr({
       rewriter.getIndexAttr(0),
       rewriter.getIndexAttr(1),
-      getI64ElementsAttr(conv2dOp.pad(), conv2dOp.getContext()),
-      getI64ElementsAttr(conv2dOp.stride(), conv2dOp.getContext()),
-      getI64ElementsAttr(conv2dOp.dilation(), conv2dOp.getContext()),
+      getI64ElementsAttr(convOp.pad(), convOp.getContext()),
+      getI64ElementsAttr(convOp.stride(), convOp.getContext()),
+      getI64ElementsAttr(convOp.dilation(), convOp.getContext()),
     });
     // clang-format on
 
     ArrayAttr templateArgs =
-        rewriter.getArrayAttr({TypeAttr::get(conv2dOp.getResult().getType())});
+        rewriter.getArrayAttr({TypeAttr::get(convOp.getResult().getType())});
 
-    // create conv2dOp
+    // create convOp
     auto emitcConvOp =
-        rewriter.create<emitc::CallOp>(conv2dOp->getLoc(), conv2dOp.getType(),
+        rewriter.create<emitc::CallOp>(convOp->getLoc(), convOp.getType(),
                                        callee, args, templateArgs, operands);
 
     auto output = emitcConvOp.getResult(0);
     auto tosaAddOp = rewriter.create<tosa::AddOp>(
-        conv2dOp.getLoc(), output.getType(), output, conv2dOp.bias());
+        convOp.getLoc(), output.getType(), output, convOp.bias());
 
-    rewriter.replaceOp(conv2dOp, {tosaAddOp.getResult()});
+    rewriter.replaceOp(convOp, {tosaAddOp.getResult()});
 
     return success();
   }
@@ -495,8 +495,8 @@ void populateTosaToEmitcPatterns(MLIRContext *ctx,
   patterns.insert<CallOpBroadcastableConversion<tosa::SubOp>>(ctx, "tosa::sub");
 
   // Other ops
-  patterns.insert<Conv2DOpConversion<tosa::Conv2DOp>>(ctx, "tosa::conv2d");
-  patterns.insert<Conv2DOpConversion<tosa::DepthwiseConv2DOp>>(
+  patterns.insert<GenericConvOpConversion<tosa::Conv2DOp>>(ctx, "tosa::conv2d");
+  patterns.insert<GenericConvOpConversion<tosa::DepthwiseConv2DOp>>(
       ctx, "tosa::depthwise_conv2d");
   patterns.insert<FullyConnectedOpConversion>(ctx, "tosa::fully_connected");
   patterns.insert<MatMulOpConversion>(ctx);

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -133,6 +133,14 @@ func @test_conv2d(%arg0: tensor<1x4x4x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg2:
     return %0 : tensor<1x4x4x8xf32>
 }
 
+func @test_depthwise_conv2d(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<2x2x2x2xf32>, %arg2: tensor<4xf32>) -> tensor<1x3x4x4xf32> {
+    // CHECK: %0 = emitc.call "tosa::depthwise_conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>) -> tensor<1x3x4x4xf32>
+    // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [dense<3> : tensor<1xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<4xf32>) -> tensor<1x3x4x4xf32>
+    // CHECK: %2 = emitc.call "tosa::add"(%0, %1) {template_args = []} : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>, tensor<4xf32>) -> tensor<1x3x4x4xf32>
+    return %0 : tensor<1x3x4x4xf32>
+}
+
 func @test_fully_connected(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
   // CHECK: emitc.call "tosa::fully_connected"(%arg0, %arg1, %arg2) {template_args = [tensor<14x28xf32>]} : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   %0 = "tosa.fully_connected"(%arg0, %arg1, %arg2) : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -135,7 +135,7 @@ func @test_conv2d(%arg0: tensor<1x4x4x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg2:
 
 func @test_depthwise_conv2d(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<2x2x2x2xf32>, %arg2: tensor<4xf32>) -> tensor<1x3x4x4xf32> {
     // CHECK: %0 = emitc.call "tosa::depthwise_conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>) -> tensor<1x3x4x4xf32>
-    // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [dense<3> : tensor<1xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<4xf32>) -> tensor<1x3x4x4xf32>
+    // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [0 : index, dense<3> : tensor<1xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<4xf32>) -> tensor<1x3x4x4xf32>
     // CHECK: %2 = emitc.call "tosa::add"(%0, %1) {template_args = []} : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
     %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>, tensor<4xf32>) -> tensor<1x3x4x4xf32>
     return %0 : tensor<1x3x4x4xf32>

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -114,6 +114,53 @@ TEST(tosa, conv2d) {
   }
 }
 
+TEST(tosa, depthwise_conv2d) {
+  {
+    // test for channel_multiplier=1
+    using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
+    using WeightType = Tensor4D<float, 2, 2, 1, 2>; // KH KW CIN M
+    using ResultType = Tensor4D<float, 1, 3, 4, 2>; // N H W CXM
+    InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+                    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
+    WeightType weights{1, 2, 3, 4, 5, 6, 7, 8};
+    ResultType expected_result{156, 204, 188, 244, 220, 284, 252, 324,
+                               316, 404, 348, 444, 380, 484, 412, 524,
+                               476, 604, 508, 644, 540, 684, 572, 724};
+
+    Tensor1D<int64_t, 4> padding{0, 0, 0, 0}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> dilation{1, 1};
+    Tensor1D<int64_t, 2> stride{1, 1};
+
+    ResultType result = tosa::depthwise_conv2d<ResultType>(
+        input, weights, padding, stride, dilation);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+  {
+    // test for channel_multiplier=2
+    using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
+    using WeightType = Tensor4D<float, 2, 2, 2, 2>; // KH KW CIN M
+    using ResultType = Tensor4D<float, 1, 3, 4, 4>; // N H W CXM
+    InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
+                    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+                    29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40};
+    WeightType weights{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    ResultType expected_result{
+        284, 312,  376,  408,  340, 376,  448,  488,  396,  440,  520,  568,
+        452, 504,  592,  648,  564, 632,  736,  808,  620,  696,  808,  888,
+        676, 760,  880,  968,  732, 824,  952,  1048, 844,  952,  1096, 1208,
+        900, 1016, 1168, 1288, 956, 1080, 1240, 1368, 1012, 1144, 1312, 1448};
+
+    Tensor1D<int64_t, 4> padding{0, 0, 0, 0}; // {pt, pb, pl, pr}
+    Tensor1D<int64_t, 2> dilation{1, 1};
+    Tensor1D<int64_t, 2> stride{1, 1};
+
+    ResultType result = tosa::depthwise_conv2d<ResultType>(
+        input, weights, padding, stride, dilation);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+}
+
 TEST(tosa, fully_connected) {
   using InputType = Tensor2D<float, 2, 5>;  // N CIN
   using WeightType = Tensor2D<float, 2, 5>; // COUT CIN

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -118,7 +118,7 @@ TEST(tosa, depthwise_conv2d) {
   {
     // test for channel_multiplier=1
     using InputType = Tensor4D<float, 1, 4, 5, 2>;  // N H W C
-    using WeightType = Tensor4D<float, 2, 2, 1, 2>; // KH KW CIN M
+    using WeightType = Tensor4D<float, 2, 2, 2, 1>; // KH KW CIN M
     using ResultType = Tensor4D<float, 1, 3, 4, 2>; // N H W CXM
     InputType input{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
                     15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,

--- a/unittests/emitc_types.cpp
+++ b/unittests/emitc_types.cpp
@@ -614,6 +614,26 @@ TEST(types, ravel_index) {
   EXPECT_EQ(t4.ravel_index({1, 2, 3, 4}), 211);
 }
 
+TEST(types, ravel_index_utility_function) {
+  size_t test_1 = ravel_index<12>(0);
+  size_t test_2 = ravel_index<12>(7);
+  size_t test_3 = ravel_index<3, 7>(0, 2);
+  size_t test_4 = ravel_index<3, 7>(2, 3);
+  size_t test_5 = ravel_index<2, 4, 6>(0, 2, 0);
+  size_t test_6 = ravel_index<2, 4, 6>(1, 3, 4);
+  size_t test_7 = ravel_index<2, 3, 4, 9>(1, 0, 0, 3);
+  size_t test_8 = ravel_index<2, 3, 4, 9>(1, 2, 3, 4);
+
+  EXPECT_EQ(test_1, 0);
+  EXPECT_EQ(test_2, 7);
+  EXPECT_EQ(test_3, 2);
+  EXPECT_EQ(test_4, 17);
+  EXPECT_EQ(test_5, 12);
+  EXPECT_EQ(test_6, 46);
+  EXPECT_EQ(test_7, 111);
+  EXPECT_EQ(test_8, 211);
+}
+
 TEST(types, unravel_index) {
   Tensor0D<uint16_t> t0;
   Tensor1D<int8_t, 12> t1;

--- a/unittests/emitc_types.cpp
+++ b/unittests/emitc_types.cpp
@@ -614,26 +614,6 @@ TEST(types, ravel_index) {
   EXPECT_EQ(t4.ravel_index({1, 2, 3, 4}), 211);
 }
 
-TEST(types, ravel_index_utility_function) {
-  size_t test_1 = ravel_index<12>(0);
-  size_t test_2 = ravel_index<12>(7);
-  size_t test_3 = ravel_index<3, 7>(0, 2);
-  size_t test_4 = ravel_index<3, 7>(2, 3);
-  size_t test_5 = ravel_index<2, 4, 6>(0, 2, 0);
-  size_t test_6 = ravel_index<2, 4, 6>(1, 3, 4);
-  size_t test_7 = ravel_index<2, 3, 4, 9>(1, 0, 0, 3);
-  size_t test_8 = ravel_index<2, 3, 4, 9>(1, 2, 3, 4);
-
-  EXPECT_EQ(test_1, 0);
-  EXPECT_EQ(test_2, 7);
-  EXPECT_EQ(test_3, 2);
-  EXPECT_EQ(test_4, 17);
-  EXPECT_EQ(test_5, 12);
-  EXPECT_EQ(test_6, 46);
-  EXPECT_EQ(test_7, 111);
-  EXPECT_EQ(test_8, 211);
-}
-
 TEST(types, unravel_index) {
   Tensor0D<uint16_t> t0;
   Tensor1D<int8_t, 12> t1;


### PR DESCRIPTION
Adds a conversion for `tosa.depthwise_conv2d`, the corresponding unittest and regression test. Also adds utility functions to calculate the index to a flat array for a given shape and indices (ravel index). This is needed in the `depthwise_conv2d` implementation.