### PR TITLE
Fix tosa.reluN conversion

### DIFF
--- a/include/emitc/emitc_core_ops.h
+++ b/include/emitc/emitc_core_ops.h
@@ -94,7 +94,7 @@ inline Src clamp(Min min, Src operand, Max max) {
       std::is_same<Max, Src>::value ||
           (is_tensor_of_dim<0, Max>::value &&
            std::is_same<typename get_element_type<Src>::type,
-                        typename get_element_type<Min>::type>::value),
+                        typename get_element_type<Max>::type>::value),
       "Expected the same type for min and operand or a 0-dim tensor of the "
       "same element type for max");
 

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -63,10 +63,10 @@ inline Src reciprocal(Src x) {
 }
 
 // ReluNOp
-template <typename Src, typename Limit>
-inline Src reluN(Src operand, Limit max_value) {
-  Tensor0D<Limit> min{0};
-  Tensor0D<Limit> max{max_value};
+template <typename Src>
+inline Src reluN(Src operand, typename Src::value_type max_value) {
+  Tensor<typename Src::value_type> min{0};
+  Tensor<typename Src::value_type> max{max_value};
   return emitc::clamp(min, operand, max);
 }
 

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -244,13 +244,21 @@ private:
     args_.push_back(rewriter.getIndexAttr(0));
 
     // Since tosa.reluN has two max attribute types for float and integer
-    // values, we have to determine to which max attribute we have to clamp to
+    // values, we have to determine to which max attribute we have to clamp to.
+    // We also need to adjust the max attribute type bit width, such that they
+    // match the operand's element type, because TOSA specifies the max
+    // attributes to be exact i64 or f32, regardless of the operand's element
+    // type bit width.
     auto elementType =
         operands[0].getType().cast<RankedTensorType>().getElementType();
     if (elementType.isa<IntegerType>()) {
-      args_.push_back(reluNOp.max_intAttr());
+      // Change the max_int type to the element type of the operand
+      auto maxInt = reluNOp.max_int();
+      args_.push_back(mlir::IntegerAttr::get(elementType, maxInt));
     } else if (elementType.isa<FloatType>()) {
-      args_.push_back(reluNOp.max_fpAttr());
+      // Change the max_fp type to the element type of the operand
+      auto maxFp = reluNOp.max_fpAttr().getValueAsDouble();
+      args_.push_back(mlir::FloatAttr::get(elementType, maxFp));
     } else {
       return reluNOp.emitError(
           "Operand of tosa.reluN has to be tensor of integer or float values.");

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -243,12 +243,10 @@ private:
     SmallVector<Attribute, 2> args_;
     args_.push_back(rewriter.getIndexAttr(0));
 
-    // Since tosa.reluN has two max attribute types for float and integer
-    // values, we have to determine to which max attribute we have to clamp to.
-    // We also need to adjust the max attribute type bit width, such that they
-    // match the operand's element type, because TOSA specifies the max
-    // attributes to be exact i64 or f32, regardless of the operand's element
-    // type bit width.
+    // TOSA specifies the max attributes to be either exact i64 or f32,
+    // regardless of the operand's element type. So we need to make sure that
+    // the max attribute type match the operand's element type and it's bit
+    // width.
     auto elementType =
         operands[0].getType().cast<RankedTensorType>().getElementType();
     if (elementType.isa<IntegerType>()) {

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -221,3 +221,15 @@ func @test_relu1(%arg0: tensor<13x21x3xi64>) -> tensor<13x21x3xi64> {
   %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
   return %0 : tensor<13x21x3xi64>
 }
+
+func @test_relu2(%arg0: tensor<13x21x3xi32>) -> tensor<13x21x3xi32> {
+  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 255 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  return %0 : tensor<13x21x3xi32>
+}
+
+func @test_relu3(%arg0: tensor<13x21x3xf16>) -> tensor<13x21x3xf16> {
+  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 1.500000e+00 : f16]} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
+  %0 = "tosa.reluN"(%arg0) {max_fp = 1.5 : f32, max_int = 0 : i64} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
+  return %0 : tensor<13x21x3xf16>
+}


### PR DESCRIPTION
Fixes the case, where the bit width of the operand does not match the one from the max attributes.