### PR TITLE
Add missing import for C Target

### DIFF
--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -343,6 +343,7 @@ static LogicalResult printModule(CppEmitter &emitter, ModuleOp moduleOp) {
 
   if (emitter.restrictedToC()) {
     os << "#include <stdbool.h>\n";
+    os << "#include <stddef.h>\n";
     os << "#include <stdint.h>\n\n";
   } else {
     os << "#include <cmath>\n\n";


### PR DESCRIPTION
This include makes the `size_t` available in C.