### PR TITLE
Add a TOSA e2e test to our pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -99,8 +99,52 @@ jobs:
         python3 ../${EMITC}/scripts/tf_to_mhlo_dialect.py model_tf_opt.mlir ../${E2E}/model_mhlo.mlir
         python3 ../${EMITC}/scripts/generate_testscases.py --file-format cpp --count 1 --batch-size 2 --seed 1234 mobilenet_v2.h5 ../${E2E}/
 
-  build:
-    name: Build and test EmitC
+  build-debug:
+    name: Build and test EmitC (Debug)
+    needs: build-llvm
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Configure environment
+      run: echo "$GITHUB_WORKSPACE/${LLVM}/install/bin" >> $GITHUB_PATH
+
+    - name: Checkout EmitC
+      uses: actions/checkout@v2
+      with:
+        path: ${{ env.EMITC }}
+        submodules: 'true'
+
+    - name: Get LLVM hash
+      id: get-llvm-hash
+      run: echo "llvm_hash=$(cat ${{ env.EMITC }}/build_tools/llvm_version.txt)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Cache LLVM
+      id: cache-llvm
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.LLVM }}
+        key: ${{ runner.os }}-llvm-20.04-install-${{ env.llvm_hash }}
+
+    - name: Build and test EmitC
+      id: build-emitc-debug
+      run: |
+        mkdir -p ${EMITC}/build_debug
+        cd ${EMITC}/build_debug
+        cmake .. \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DLLVM_ENABLE_ASSERTIONS=ON \
+          -DMLIR_DIR=$GITHUB_WORKSPACE/${LLVM}/install/lib/cmake/mlir/ \
+          -DLLVM_DIR=$GITHUB_WORKSPACE/${LLVM}/install/lib/cmake/llvm/ \
+          -DCMAKE_LINKER=lld \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
+        cmake --build . --target check-emitc -- -j$(nproc)
+        cmake --build . --target MLIREmitCAllTests -- -j$(nproc)
+        ./unittests/MLIREmitCAllTests
+
+  build-release:
+    name: Build and test EmitC (Release)
     needs: [build-llvm, prepare-e2e-test]
     runs-on: ubuntu-20.04
     steps:
@@ -125,25 +169,7 @@ jobs:
         path: ${{ env.LLVM }}
         key: ${{ runner.os }}-llvm-20.04-install-${{ env.llvm_hash }}
 
-    - name: Build and test EmitC (Debug)
-      id: build-emitc-debug
-      run: |
-        mkdir -p ${EMITC}/build_debug
-        cd ${EMITC}/build_debug
-        cmake .. \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DLLVM_ENABLE_ASSERTIONS=ON \
-          -DMLIR_DIR=$GITHUB_WORKSPACE/${LLVM}/install/lib/cmake/mlir/ \
-          -DLLVM_DIR=$GITHUB_WORKSPACE/${LLVM}/install/lib/cmake/llvm/ \
-          -DCMAKE_LINKER=lld \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
-        cmake --build . --target check-emitc -- -j$(nproc)
-        cmake --build . --target MLIREmitCAllTests -- -j$(nproc)
-        ./unittests/MLIREmitCAllTests
-
-    - name: Build and test EmitC (Release)
+    - name: Build and test EmitC
       id: build-emitc-release
       run: |
         mkdir -p ${EMITC}/build_release

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -167,7 +167,7 @@ jobs:
         path: ${{ env.E2E }}
         key: ${{ runner.os }}-e2e-${{ hashFiles('emitc/scripts/*.py', 'emitc/scripts/requirements.txt') }}
 
-    - name: Run e2e test
+    - name: Run MHLO e2e test
       run: |
         ./${EMITC}/build_release/bin/emitc-opt --canonicalize --inline --symbol-dce ${E2E}/model_mhlo.mlir > ${E2E}/model_canon.mlir
         FUNCTION_NAME=$(grep -oe "@[^(]*" "${E2E}"/model_canon.mlir)
@@ -177,4 +177,14 @@ jobs:
         ./${EMITC}/build_release/bin/emitc-translate --mlir-to-cpp "${E2E}"/model_emitc.mlir > "${E2E}"/model_generated.h
         cd ${E2E}
         clang++ test.cpp -O3 -I `pwd`/../emitc/include/emitc -I `pwd` -o test
+        ./test
+
+    - name: Run TOSA e2e test
+      run: |
+        mkdir -p ${EMITC}/build_e2e
+        ./${EMITC}/build_release/bin/emitc-opt --convert-tosa-to-emitc ${EMITC}/test/MobileNetV2_tosa.mlir > ${EMITC}/build_e2e/model_emitc.mlir
+        ./${EMITC}/build_release/bin/emitc-translate --mlir-to-cpp ${EMITC}/build_e2e/model_emitc.mlir > ${EMITC}/build_e2e/model_generated.h
+        cp ${EMITC}/test/MobileNetV2_tosa_test.cpp ${EMITC}/build_e2e/test.cpp
+        cd ${EMITC}/build_e2e/
+        clang++ test.cpp -O3 -I `pwd`/../include/emitc -I `pwd` -o test
         ./test


### PR DESCRIPTION
Adds a first TOSA e2e test to our pipeline and splits the workflow to build and test the release and debug build in parallel.