### PR TITLE
Add more checks to emitc::CallOp verifier

### DIFF
--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -97,28 +97,7 @@ def EmitC_CallOp : EmitC_Op<"call", []> {
   let assemblyFormat = [{
     $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
   }];
-  let verifier = [{
-    // callee must not be empty
-    if (callee().empty()) {
-      return emitOpError("callee must not be empty");
-    }
-    // args elements of type index must be in range [0..operands.size)
-    auto argsAttr = args();
-    if (argsAttr.hasValue()) {
-      for (auto &arg : argsAttr.getValue()) {
-        if (auto iArg = arg.dyn_cast<IntegerAttr>()) {
-          if (iArg.getType().isIndex()) {
-            int64_t index = iArg.getInt();
-            if ((index < 0) || (index >= static_cast<int64_t>(getNumOperands()))) {
-              return emitOpError("index argument is out of range");
-            }
-          }
-        }
-      }
-    }
-    return success();
-  }];
-
+  let verifier = [{ return ::verify(*this); }];
 }
 
 def EmitC_ConstOp : EmitC_Op<"const", [ConstantLike, NoSideEffect]> {

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -90,7 +90,7 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
       if (auto iArg = tArg.dyn_cast<FloatAttr>()) {
         return op.emitOpError("float literal as template argument is invalid");
       }
-      // Template args with elements of type ArrayAttr are not allowed
+      // Template args with elements of type ArrayAttr are not allowed.
       else if (auto aArg = tArg.dyn_cast<ArrayAttr>()) {
         return op.emitOpError("array as template arguments is invalid");
       }

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -88,21 +88,15 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
       // C++ forbids float literals as template arguments.
       if (auto iArg = tArg.dyn_cast<FloatAttr>()) {
         return op.emitOpError("float literal as template argument is invalid");
-      } else if (auto aArg = tArg.dyn_cast<ArrayAttr>()) {
-        // Template args with elements of type array must have a type.
-        if (aArg.getType().isa<NoneType>()) {
-          return op.emitOpError("array template argument has no type");
-        }
-        // Template args with elements of type array may not be of type float,
-        // since C++ forbids float literals as template arguments.
-        if (aArg.getType().isa<FloatType>()) {
-          return op.emitOpError(
-              "float literals as template arguments are invalid");
-        }
-        // Template args  with elements of type DenseFPElementsAttr are not
-        // allowed.
-      } else if (auto dArg = tArg.dyn_cast<DenseFPElementsAttr>()) {
-        return op.emitOpError("dense float elements as template "
+      }
+      // Template args with elements of type array are not allowed
+      else if (auto aArg = tArg.dyn_cast<ArrayAttr>()) {
+        return op.emitOpError("array as template arguments is invalid");
+      }
+      // Template args with elements of type DenseElementsAttr are not
+      // allowed.
+      else if (auto dArg = tArg.dyn_cast<DenseElementsAttr>()) {
+        return op.emitOpError("dense elements as template "
                               "argument are invalid");
       }
     }

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -55,7 +55,7 @@ void emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
 //===----------------------------------------------------------------------===//
 
 static LogicalResult verify(mlir::emitc::CallOp op) {
-  // callee must not be empty.
+  // Callee must not be empty.
   if (op.callee().empty()) {
     return op.emitOpError("callee must not be empty");
   }
@@ -63,7 +63,7 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
   auto argsAttr = op.args();
   if (argsAttr.hasValue()) {
     for (auto &arg : argsAttr.getValue()) {
-      // args elements of type index must be in range [0..operands.size).
+      // Args with elements of type index must be in range [0..operands.size).
       if (auto iArg = arg.dyn_cast<IntegerAttr>()) {
         if (iArg.getType().isIndex()) {
           int64_t index = iArg.getInt();
@@ -73,7 +73,7 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
           }
         }
       }
-      // args elements of type ArrayAttr must have a type.
+      // Args with elements of type ArrayAttr must have a type.
       else if (auto aArg = arg.dyn_cast<ArrayAttr>()) {
         if (aArg.getType().isa<NoneType>()) {
           return op.emitOpError("array argument has no type");
@@ -89,19 +89,20 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
       if (auto iArg = tArg.dyn_cast<FloatAttr>()) {
         return op.emitOpError("float literal as template argument is invalid");
       } else if (auto aArg = tArg.dyn_cast<ArrayAttr>()) {
-        // template_args elements of type ArrayAttr must have a type.
+        // Template args with elements of type array must have a type.
         if (aArg.getType().isa<NoneType>()) {
           return op.emitOpError("array template argument has no type");
         }
-        // template_args elements of type ArrayAttr may not be of type float,
+        // Template args with elements of type array may not be of type float,
         // since C++ forbids float literals as template arguments.
         if (aArg.getType().isa<FloatType>()) {
           return op.emitOpError(
               "float literals as template arguments are invalid");
         }
-        // template_args elements of type DenseElementsAttr are not allowed.
-      } else if (auto dArg = tArg.dyn_cast<DenseElementsAttr>()) {
-        return op.emitOpError("dense elements as template "
+        // Template args  with elements of type DenseFPElementsAttr are not
+        // allowed.
+      } else if (auto dArg = tArg.dyn_cast<DenseFPElementsAttr>()) {
+        return op.emitOpError("dense float elements as template "
                               "argument are invalid");
       }
     }

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -63,10 +63,11 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
   auto argsAttr = op.args();
   if (argsAttr.hasValue()) {
     for (auto &arg : argsAttr.getValue()) {
-      // Args with elements of type index must be in range [0..operands.size).
       if (auto iArg = arg.dyn_cast<IntegerAttr>()) {
         if (iArg.getType().isIndex()) {
           int64_t index = iArg.getInt();
+          // Args with elements of type index must be in range
+          // [0..operands.size).
           if ((index < 0) ||
               (index >= static_cast<int64_t>(op.getNumOperands()))) {
             return op.emitOpError("index argument is out of range");
@@ -89,7 +90,7 @@ static LogicalResult verify(mlir::emitc::CallOp op) {
       if (auto iArg = tArg.dyn_cast<FloatAttr>()) {
         return op.emitOpError("float literal as template argument is invalid");
       }
-      // Template args with elements of type array are not allowed
+      // Template args with elements of type ArrayAttr are not allowed
       else if (auto aArg = tArg.dyn_cast<ArrayAttr>()) {
         return op.emitOpError("array as template arguments is invalid");
       }

--- a/test/Dialect/EmitC/invalid_ops.mlir
+++ b/test/Dialect/EmitC/invalid_ops.mlir
@@ -32,14 +32,6 @@ func @nonetype_arg(%arg : i32) {
 
 // -----
 
-func @nonetype_template_arg(%arg : i32) {
-    // expected-error @+1 {{'emitc.call' op array template argument has no type}}
-    emitc.call "nonetype_template_arg"(%arg) {template_args = [[0, 1, 2]]} : (i32) -> i32
-    return
-}
-
-// -----
-
 func @float_template_argument(%arg : i32) {
     // expected-error @+1 {{'emitc.call' op float literal as template argument is invalid}}
     emitc.call "float_template_argument"(%arg) {template_args = [0.5 : f32]} : (i32) -> i32
@@ -48,8 +40,16 @@ func @float_template_argument(%arg : i32) {
 
 // -----
 
+func @array_template_arg(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op array as template arguments is invalid}}
+    emitc.call "nonetype_template_arg"(%arg) {template_args = [[0, 1, 2]]} : (i32) -> i32
+    return
+}
+
+// -----
+
 func @dense_template_argument(%arg : i32) {
-    // expected-error @+1 {{'emitc.call' op dense float elements as template argument are invalid}}
+    // expected-error @+1 {{'emitc.call' op dense elements as template argument are invalid}}
     emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1.0, 1.0]> : tensor<2xf32>]} : (i32) -> i32
     return
 }

--- a/test/Dialect/EmitC/invalid_ops.mlir
+++ b/test/Dialect/EmitC/invalid_ops.mlir
@@ -49,15 +49,7 @@ func @float_template_argument(%arg : i32) {
 // -----
 
 func @dense_template_argument(%arg : i32) {
-    // expected-error @+1 {{'emitc.call' op dense elements as template argument are invalid}}
+    // expected-error @+1 {{'emitc.call' op dense float elements as template argument are invalid}}
     emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1.0, 1.0]> : tensor<2xf32>]} : (i32) -> i32
-    return
-}
-
-// -----
-
-func @dense_template_argument2(%arg : i32) {
-    // expected-error @+1 {{'emitc.call' op dense elements as template argument are invalid}}
-    emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1, 1]> : tensor<2xi32>]} : (i32) -> i32
     return
 }

--- a/test/Dialect/EmitC/invalid_ops.mlir
+++ b/test/Dialect/EmitC/invalid_ops.mlir
@@ -1,20 +1,63 @@
 // RUN: emitc-opt %s -split-input-file -verify-diagnostics
 
 func @index_args_out_of_range_1() {
-    emitc.call "test" () {args = [0 : index]} : () -> () // expected-error {{'emitc.call' op index argument is out of range}}
+    // expected-error @+1 {{'emitc.call' op index argument is out of range}}
+    emitc.call "test" () {args = [0 : index]} : () -> ()
     return
 }
 
 // -----
 
 func @index_args_out_of_range_2(%arg : i32) {
-    emitc.call "test" (%arg, %arg) {args = [2 : index]} : (i32, i32) -> () // expected-error {{'emitc.call' op index argument is out of range}}
+    // expected-error @+1 {{'emitc.call' op index argument is out of range}}
+    emitc.call "test" (%arg, %arg) {args = [2 : index]} : (i32, i32) -> ()
     return
 }
 
 // -----
 
 func @empty_callee() {
-    emitc.call "" () : () -> () // expected-error {{'emitc.call' op callee must not be empty}}
+    // expected-error @+1 {{'emitc.call' op callee must not be empty}}
+    emitc.call "" () : () -> ()
+    return
+}
+
+// -----
+
+func @nonetype_arg(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op array argument has no type}}
+    emitc.call "nonetype_arg"(%arg) {args = [0 : index, [0, 1, 2]]} : (i32) -> i32
+    return
+}
+
+// -----
+
+func @nonetype_template_arg(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op array template argument has no type}}
+    emitc.call "nonetype_template_arg"(%arg) {template_args = [[0, 1, 2]]} : (i32) -> i32
+    return
+}
+
+// -----
+
+func @float_template_argument(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op float literal as template argument is invalid}}
+    emitc.call "float_template_argument"(%arg) {template_args = [0.5 : f32]} : (i32) -> i32
+    return
+}
+
+// -----
+
+func @dense_template_argument(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op dense elements as template argument are invalid}}
+    emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1.0, 1.0]> : tensor<2xf32>]} : (i32) -> i32
+    return
+}
+
+// -----
+
+func @dense_template_argument2(%arg : i32) {
+    // expected-error @+1 {{'emitc.call' op dense elements as template argument are invalid}}
+    emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1, 1]> : tensor<2xi32>]} : (i32) -> i32
     return
 }


### PR DESCRIPTION
This adds the following checks to the `emitC::CallOp` verifier:
- args: arguments need a type
- template_args: arguments need a type, forbid float literals, forbid dense elements attributes