### PR TITLE
Expand and refactor tests

### DIFF
--- a/test/Conversion/mhlo-to-emitc.mlir
+++ b/test/Conversion/mhlo-to-emitc.mlir
@@ -12,91 +12,91 @@ func @mhlo_constant(%arg0: tensor<2xi32>) -> tensor<2xi32> {
 // Unary elementwise ops
 
 func @float_abs(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::abs"
+  // CHECK: emitc.call "mhlo::abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_ceil(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::ceil"
+  // CHECK: emitc.call "mhlo::ceil"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.ceil"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_convert(%arg0: tensor<ui32>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::convert"(%arg0) {template_args = [tensor<ui64>]}
+  // CHECK: emitc.call "mhlo::convert"(%arg0) {template_args = [tensor<ui64>]} : (tensor<ui32>) -> tensor<ui64>
   %0 = "mhlo.convert"(%arg0) : (tensor<ui32>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
 
 func @mhlo_cos(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::cos"
+  // CHECK: emitc.call "mhlo::cos"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.cosine"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_exponential(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::exponential"
+  // CHECK: emitc.call "mhlo::exponential"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.exponential"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_exponential_minus_one(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::exponential_minus_one"
+  // CHECK: emitc.call "mhlo::exponential_minus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.exponential_minus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_floor(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::floor"
+  // CHECK: emitc.call "mhlo::floor"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.floor"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_is_finite(%arg0: tensor<4xf32>) -> tensor<4xi1> {
-  // CHECK: emitc.call "mhlo::is_finite"
+  // CHECK: emitc.call "mhlo::is_finite"(%arg0) : (tensor<4xf32>) -> tensor<4xi1>
   %0 = "mhlo.is_finite"(%arg0) : (tensor<4xf32>) -> tensor<4xi1>
   return %0 : tensor<4xi1>
 }
 
 func @mhlo_log(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::log"
+  // CHECK: emitc.call "mhlo::log"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.log"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_log_plus_one(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::log_plus_one"
+  // CHECK: emitc.call "mhlo::log_plus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.log_plus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_negate(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::negate"
+  // CHECK: emitc.call "mhlo::negate"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.negate"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_round(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::round"
+  // CHECK: emitc.call "mhlo::round"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.round_nearest_afz"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_sine(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::sin"
+  // CHECK: emitc.call "mhlo::sin"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.sine"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_sqrt(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::sqrt"
+  // CHECK: emitc.call "mhlo::sqrt"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.sqrt"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_tanh(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::tanh"
+  // CHECK: emitc.call "mhlo::tanh"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.tanh"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
@@ -105,13 +105,13 @@ func @mhlo_tanh(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 // Binary elementwise ops
 
 func @mhlo_add_i64(%arg0: tensor<i64>) -> tensor<i64> {
-  // CHECK: emitc.call "mhlo::add"
+  // CHECK: emitc.call "mhlo::add"(%arg0, %arg0) : (tensor<i64>, tensor<i64>) -> tensor<i64>
   %0 = mhlo.add %arg0, %arg0 : tensor<i64>
   return %0 : tensor<i64>
 }
 
 func @mhlo_add_f64(%arg0: tensor<f64>) -> tensor<f64> {
-  // CHECK: emitc.call "mhlo::add"
+  // CHECK: emitc.call "mhlo::add"(%arg0, %arg0) : (tensor<f64>, tensor<f64>) -> tensor<f64>
   %0 = mhlo.add %arg0, %arg0 : tensor<f64>
   return %0 : tensor<f64>
 }
@@ -123,49 +123,49 @@ func @mhlo_atan2(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
 }
 
 func @mhlo_divide(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::div"
+  // CHECK: emitc.call "mhlo::div"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.divide"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_max(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: emitc.call "mhlo::max"
+  // CHECK: emitc.call "mhlo::max"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   %0 = "mhlo.maximum"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
 func @mhlo_min(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: emitc.call "mhlo::min"
+  // CHECK: emitc.call "mhlo::min"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   %0 = "mhlo.minimum"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
 func @mhlo_multiply(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::mul"
+  // CHECK: emitc.call "mhlo::mul"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.multiply"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_power(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::pow"
+  // CHECK: emitc.call "mhlo::pow"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.power"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_shift_left(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::shift_left"
+  // CHECK: emitc.call "mhlo::shift_left"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.shift_left"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_shift_right_logical(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::shift_right_logical"
+  // CHECK: emitc.call "mhlo::shift_right_logical"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.shift_right_logical"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_sub(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::sub"
+  // CHECK: emitc.call "mhlo::sub"(%arg0, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.subtract"(%arg0, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
@@ -174,13 +174,13 @@ func @mhlo_sub(%arg0: tensor<f32>) -> tensor<f32> {
 // Binary logical elementwise ops
 
 func @mhlo_or(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::logical_or"(%arg0, %arg1)
+  // CHECK: emitc.call "mhlo::logical_or"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   %0 = "mhlo.or"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
 
 func @mhlo_xor(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::logical_xor"(%arg0, %arg1)
+  // CHECK: emitc.call "mhlo::logical_xor"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   %0 = "mhlo.xor"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
@@ -189,44 +189,46 @@ func @mhlo_xor(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
 // Tuple ops
 
 func @mhlo_tuple(%arg0: tensor<i32>, %arg1: tensor<ui64>) -> (tuple<tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>>) {
-  // CHECK: emitc.call "std::make_tuple"()
+  // CHECK: emitc.call "std::make_tuple"() : () -> tuple<>
   %0 = "mhlo.tuple"() : () -> tuple<>
-  // CHECK: emitc.call "std::make_tuple"(%arg0)
+  // CHECK: emitc.call "std::make_tuple"(%arg0) : (tensor<i32>) -> tuple<tensor<i32>>
   %1 = "mhlo.tuple"(%arg0) : (tensor<i32>) -> tuple<tensor<i32>>
-  // CHECK: emitc.call "std::make_tuple"(%arg0, %arg1)
+  // CHECK: emitc.call "std::make_tuple"(%arg0, %arg1) : (tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>>
   %2 = "mhlo.tuple"(%arg0, %arg1) : (tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>>
-  // CHECK: emitc.call "std::make_tuple"(%arg0, %arg1, %arg0, %arg1)
+  // CHECK: emitc.call "std::make_tuple"(%arg0, %arg1, %arg0, %arg1) : (tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>>
   %3 = "mhlo.tuple"(%arg0, %arg1, %arg0, %arg1) : (tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>>
   return %3 : tuple<tensor<i32>, tensor<ui64>, tensor<i32>, tensor<ui64>>
 }
 
 func @mhlo_tuple_nested(%arg0: tensor<i32>, %arg1: tensor<ui64>) -> tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>> {
+  // CHECK: emitc.call "std::make_tuple"(%arg0, %arg1) : (tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>>
   %0 = "mhlo.tuple"(%arg0, %arg1) : (tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tensor<ui64>>
+  // CHECK: emitc.call "std::make_tuple"(%arg0, %0) : (tensor<i32>, tuple<tensor<i32>, tensor<ui64>>) -> tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>
   %1 = "mhlo.tuple"(%arg0, %0) : (tensor<i32>, tuple<tensor<i32>, tensor<ui64>>) -> tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>
   return %1 : tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>
 }
 
 func @mhlo_tuple_unpack(%arg0: tensor<i32>, %arg1: tensor<ui64>) -> (tuple<tensor<i32>, tensor<ui64>>, tensor<i32>) {
   %0 = call @mhlo_tuple_nested(%arg0, %arg1) : (tensor<i32>, tensor<ui64>) -> tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>
-  // CHECK: emitc.call "std::get"(%0) {template_args = [1 : i32]}
+  // CHECK: emitc.call "std::get"(%0) {template_args = [1 : i32]} : (tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>) -> tuple<tensor<i32>, tensor<ui64>>
   %1 = "mhlo.get_tuple_element"(%0) {index = 1 : i32} : (tuple<tensor<i32>, tuple<tensor<i32>, tensor<ui64>>>) -> tuple<tensor<i32>, tensor<ui64>>
-  // CHECK: emitc.call "std::get"(%1) {template_args = [0 : i32]}
+  // CHECK: emitc.call "std::get"(%1) {template_args = [0 : i32]} : (tuple<tensor<i32>, tensor<ui64>>) -> tensor<i32>
   %2 = "mhlo.get_tuple_element"(%1) {index = 0 : i32} : (tuple<tensor<i32>, tensor<ui64>>) -> tensor<i32>
   return %1, %2 : tuple<tensor<i32>, tensor<ui64>>, tensor<i32>
 }
 
 func @mhlo_compare(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi1> {
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less_equal"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %1 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "LE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %2 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "GT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater_equal"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %3 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "GE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::equal_to"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %4 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "EQ"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::not_equal_to"]}
+  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::not_equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %5 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "NE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
 
   return %0 : tensor<4xi1>
@@ -236,19 +238,19 @@ func @mhlo_compare(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi1> {
 // Slice ops
 
 func @mhlo_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -> tensor<4x3xi32> {
-  // CHECK: emitc.call "mhlo::slice"(%arg0) {args = [0 : index, dense<0> : tensor<1xi64>, dense<1> : tensor<1xi64>, dense<1> : tensor<1xi64>], template_args = [tensor<1xi32>]}
+  // CHECK: emitc.call "mhlo::slice"(%arg0) {args = [0 : index, dense<0> : tensor<1xi64>, dense<1> : tensor<1xi64>, dense<1> : tensor<1xi64>], template_args = [tensor<1xi32>]} : (tensor<12xi32>) -> tensor<1xi32>
   %0 = "mhlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<12xi32>) -> tensor<1xi32>
-  // CHECK: emitc.call "mhlo::slice"(%arg1) {args = [0 : index, dense<0> : tensor<2xi64>, dense<[4, 3]> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<4x3xi32>]}
-  %1 = "mhlo.slice"(%arg1) {limit_indices = dense<[4, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x7xi32>) -> tensor<4x3xi32>    
+  // CHECK: emitc.call "mhlo::slice"(%arg1) {args = [0 : index, dense<0> : tensor<2xi64>, dense<[4, 3]> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<4x3xi32>]} : (tensor<8x7xi32>) -> tensor<4x3xi32>
+  %1 = "mhlo.slice"(%arg1) {limit_indices = dense<[4, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x7xi32>) -> tensor<4x3xi32>
   return %1 : tensor<4x3xi32>
 }
 
 func @mhlo_dynamic_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -> () {
   %cst = "std.constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %cst_0 = "std.constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
-  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg0, %cst) {args = [0 : index, 1 : index, dense<4> : tensor<1xi64>], template_args = [tensor<4xi32>]}
+  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg0, %cst) {args = [0 : index, 1 : index, dense<4> : tensor<1xi64>], template_args = [tensor<4xi32>]} : (tensor<12xi32>, tensor<i64>) -> tensor<4xi32>
   %0 = "mhlo.dynamic-slice"(%arg0, %cst) {slice_sizes = dense<4> : tensor<1xi64>} : (tensor<12xi32>, tensor<i64>) -> tensor<4xi32>
-  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg1, %cst, %cst_0) {args = [0 : index, 1 : index, 2 : index, dense<[4, 2]> : tensor<2xi64>], template_args = [tensor<4x2xi32>]}
+  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg1, %cst, %cst_0) {args = [0 : index, 1 : index, 2 : index, dense<[4, 2]> : tensor<2xi64>], template_args = [tensor<4x2xi32>]} : (tensor<8x7xi32>, tensor<i64>, tensor<i64>) -> tensor<4x2xi32>
   %1 = "mhlo.dynamic-slice"(%arg1, %cst, %cst_0) {slice_sizes = dense<[4, 2]> : tensor<2xi64>} : (tensor<8x7xi32>, tensor<i64>, tensor<i64>) -> tensor<4x2xi32>
   return
 }
@@ -269,37 +271,37 @@ func @mhlo_dynamic_update_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -
 // Other ops
 
 func @mhlo_batch_norm_inference(%arg0: tensor<4x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>, %arg4: tensor<2xf32>) -> tensor<4x2xf32> {
-  // CHECK: emitc.call "mhlo::batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {args = [0 : index, 1 : index, 2 : index, 3 : index, 4 : index, 1.000000e-03 : f32, 1], template_args = [tensor<4x2xf32>, tensor<2xf32>]}
+  // CHECK: emitc.call "mhlo::batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {args = [0 : index, 1 : index, 2 : index, 3 : index, 4 : index, 1.000000e-03 : f32, 1], template_args = [tensor<4x2xf32>, tensor<2xf32>]} : (tensor<4x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<4x2xf32>
   %0 = "mhlo.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 0.001 : f32, feature_index = 1 : i64} : (tensor<4x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<4x2xf32>
   return %0 : tensor<4x2xf32>
 }
 
 func @mhlo_bitcast_convert(%arg0: tensor<ui32>) -> tensor<i32> {
-  // CHECK: emitc.call "mhlo::bitcast_convert"(%arg0) {template_args = [tensor<i32>]}
+  // CHECK: emitc.call "mhlo::bitcast_convert"(%arg0) {template_args = [tensor<i32>]} : (tensor<ui32>) -> tensor<i32>
   %0 = "mhlo.bitcast_convert"(%arg0) : (tensor<ui32>) -> tensor<i32>
   return %0 : tensor<i32>
 }
 
 func @mhlo_broadcast_in_dim(%arg0: tensor<i32>) -> tensor<3xi32> {
-  // CHECK: emitc.call "mhlo::broadcast_in_dim"(%arg0) {args = [0 : index, dense<> : tensor<0xi64>], template_args = [tensor<3xi32>]}
-  %0 = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<> : tensor<0xi64>}: (tensor<i32>) -> tensor<3xi32>
+  // CHECK: emitc.call "mhlo::broadcast_in_dim"(%arg0) {args = [0 : index, dense<> : tensor<0xi64>], template_args = [tensor<3xi32>]} : (tensor<i32>) -> tensor<3xi32>
+  %0 = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i32>) -> tensor<3xi32>
   return %0 : tensor<3xi32>
 }
 
 func @mhlo_clamp(%arg0: tensor<2x1xf32>, %arg1: tensor<2x1xf32>, %arg2: tensor<2x1xf32>) -> tensor<2x1xf32> {
-  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>]}
+  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>]} : (tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<2x1xf32>
   %0 = "mhlo.clamp"(%arg0, %arg1, %arg2) : (tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<2x1xf32>
   return %0 : tensor<2x1xf32>
 }
 
 func @mhlo_clamp_broadcast(%arg0: tensor<i32>, %arg1: tensor<4x2x1xi32>, %arg2: tensor<i32>) -> tensor<4x2x1xi32> {
-  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<i32>, tensor<4x2x1xi32>, tensor<i32>]}
+  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<i32>, tensor<4x2x1xi32>, tensor<i32>]} : (tensor<i32>, tensor<4x2x1xi32>, tensor<i32>) -> tensor<4x2x1xi32>
   %0 = "mhlo.clamp"(%arg0, %arg1, %arg2) : (tensor<i32>, tensor<4x2x1xi32>, tensor<i32>) -> tensor<4x2x1xi32>
   return %0 : tensor<4x2x1xi32>
 }
 
 func @mhlo_concaternate(%arg0: tensor<1xf32>, %arg1: tensor<2xf32>) -> tensor<3xf32> {
-  // CHECK: emitc.call "mhlo::concatenate"
+  // CHECK: emitc.call "mhlo::concatenate"(%arg0, %arg1) {template_args = [0, tensor<3xf32>]} : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
   %0 = "mhlo.concatenate"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }
@@ -331,13 +333,13 @@ func @mhlo_conv(%arg0: tensor<3x5x5x3xf32>, %arg1 : tensor<2x2x3x4xf32>) -> tens
 }
 
 func @mhlo_dot(%arg0: tensor<512x512xf32>) -> tensor<512x512xf32> {
-  // CHECK: emitc.call "mhlo::dot"(%arg0, %arg0) {template_args = [tensor<512x512xf32>]}
+  // CHECK: emitc.call "mhlo::dot"(%arg0, %arg0) {template_args = [tensor<512x512xf32>]} : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
   %0 = "mhlo.dot"(%arg0, %arg0) : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
   return %0 : tensor<512x512xf32>
 }
 
 func @mhlo_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<4x7xf32> {
-  // CHECK: emitc.call "mhlo::pad"(%arg0, %arg1)
+  // CHECK: emitc.call "mhlo::pad"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<-1> : tensor<2xi64>, dense<1> : tensor<2xi64>, dense<2> : tensor<2xi64>], template_args = [tensor<4x7xf32>]} : (tensor<2x3xf32>, tensor<f32>) -> tensor<4x7xf32>
   %0 = "mhlo.pad"(%arg0, %arg1) {
     edge_padding_low = dense<-1> : tensor<2xi64>,
     edge_padding_high = dense<1> : tensor<2xi64>,
@@ -347,14 +349,14 @@ func @mhlo_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<4x7xf32> {
 }
 
 func @mhlo_reduce(%arg0 : tensor<2x1000xf32>, %arg1 : tensor<f32>, %arg2 : tensor<2x1000xi32>, %arg3 : tensor<i32>) -> tensor<2xi32>{
-  // CHECK: emitc.call "mhlo::reduce"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_0], template_args = [tensor<2xf32>, 1]}
+  // CHECK: emitc.call "mhlo::reduce"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_0], template_args = [tensor<2xf32>, 1]} : (tensor<2x1000xf32>, tensor<f32>) -> tensor<2xf32>
   %0 = "mhlo.reduce"(%arg0, %arg1) ({
     ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
       %1 = mhlo.add %arg4, %arg5 : tensor<f32>
       "mhlo.return"(%1) : (tensor<f32>) -> ()
     }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<2x1000xf32>, tensor<f32>) -> tensor<2xf32>
   
-  // CHECK: emitc.call "mhlo::reduce"(%arg2, %arg3) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_1], template_args = [tensor<2xi32>, 1]}
+  // CHECK: emitc.call "mhlo::reduce"(%arg2, %arg3) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_1], template_args = [tensor<2xi32>, 1]} : (tensor<2x1000xi32>, tensor<i32>) -> tensor<2xi32>
   %1 = "mhlo.reduce"(%arg2, %arg3) ({
     ^bb0(%arg4: tensor<i32>, %arg5: tensor<i32>):
       %2 = mhlo.maximum %arg4, %arg5 : tensor<i32>
@@ -362,9 +364,9 @@ func @mhlo_reduce(%arg0 : tensor<2x1000xf32>, %arg1 : tensor<f32>, %arg2 : tenso
     }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<2x1000xi32>, tensor<i32>) -> tensor<2xi32>
   return %1 : tensor<2xi32>
   // CHECK: func @mhlo_reduce_lambda_0(%arg0: tensor<f32>, %arg1: tensor<f32>)
-  // CHECK: "mhlo::add"
+  // CHECK: "mhlo::add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   // CHECK: func @mhlo_reduce_lambda_1(%arg0: tensor<i32>, %arg1: tensor<i32>)
-  // CHECK: "mhlo::max"
+  // CHECK: "mhlo::max"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 }
 
 func @mhlo_reduce_window(%arg0 : tensor<2x114x114x64xf32>, %arg1 : tensor<f32>) -> tensor<2x56x56x64xf32> {
@@ -381,13 +383,13 @@ func @mhlo_reduce_window(%arg0 : tensor<2x114x114x64xf32>, %arg1 : tensor<f32>) 
 }
 
 func @mhlo_reshape(%arg0: tensor<12xf32>) -> tensor<2x3x2xf32> {
-  // CHECK: emitc.call "mhlo::reshape"(%arg0) {template_args = [tensor<2x3x2xf32>]}
+  // CHECK: emitc.call "mhlo::reshape"(%arg0) {template_args = [tensor<2x3x2xf32>]} : (tensor<12xf32>) -> tensor<2x3x2xf32>
   %0 = "mhlo.reshape"(%arg0) : (tensor<12xf32>) -> tensor<2x3x2xf32>
   return %0 : tensor<2x3x2xf32>
 }
 
 func @mhlo_select(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xi1>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::select"(%arg2, %arg0, %arg1)
+  // CHECK: emitc.call "mhlo::select"(%arg2, %arg0, %arg1) : (tensor<2xi1>, tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %1 = "mhlo.select"(%arg2, %arg0, %arg1) : (tensor<2xi1>, tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   return %1 : tensor<2xf32>
 }
@@ -400,27 +402,25 @@ func @mhlo_rng_uniform() -> () {
   %cst_0 = "std.constant"() {value = dense<100> : tensor<i32>} : () -> tensor<i32>
   %cst_1 = "std.constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
 
-  // CHECK: emitc.call "mhlo::rng_uniform"(%cst, %cst_0, %cst_1) {template_args = [tensor<2xi32>]}
+  // CHECK: emitc.call "mhlo::rng_uniform"(%cst, %cst_0, %cst_1) {template_args = [tensor<2xi32>]} : (tensor<i32>, tensor<i32>, tensor<1xi64>) -> tensor<2xi32>
   %0 = "mhlo.rng_uniform"(%cst, %cst_0, %cst_1) : (tensor<i32>, tensor<i32>, tensor<1xi64>) -> tensor<2xi32>
   
   %cst_2 = "std.constant"() {value = dense<-100.0> : tensor<f32>} : () -> tensor<f32>
   %cst_3 = "std.constant"() {value = dense<100.0> : tensor<f32>} : () -> tensor<f32>
   %cst_4 = "std.constant"() {value = dense<17> : tensor<1xi64>} : () -> tensor<1xi64>
 
-  // CHECK: emitc.call "mhlo::rng_uniform"(%cst_2, %cst_3, %cst_4) {template_args = [tensor<17xf32>]}
+  // CHECK: emitc.call "mhlo::rng_uniform"(%cst_2, %cst_3, %cst_4) {template_args = [tensor<17xf32>]} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
   %1 = "mhlo.rng_uniform"(%cst_2, %cst_3, %cst_4) : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
-
   return
 }
 
 func @mhlo_rng_bit_generator() -> () {
   %cst = "std.constant"() {value = dense<2> : tensor<3xui64>} : () -> tensor<3xui64>
 
-  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x2xui32>>, 2 : i32]}
+  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x2xui32>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
   %0 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
   
-  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x7x3xf64>>, 2 : i32]}
+  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x7x3xf64>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
   %1 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
-
   return
 }

--- a/test/Conversion/std-to-emitc.mlir
+++ b/test/Conversion/std-to-emitc.mlir
@@ -1,20 +1,30 @@
-// RUN: emitc-opt -convert-std-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s
+// RUN: emitc-opt -convert-std-to-emitc %s | FileCheck %s
+// RUN: emitc-opt -convert-std-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s -check-prefix=CPP
 
-// CHECK: Tensor<size_t, 2> std_index_cast(Tensor<size_t> v1, Tensor<int32_t, 2> v2, Tensor<int32_t, 2, 2> v3)
 func @std_index_cast(%arg0: tensor<index>, %arg1: tensor<2xi32>, %arg2: tensor<2x2xi32>) -> tensor<2xindex> {
-  // CHECK: standard::index_cast<Tensor<int32_t>>(v1)
   %0 = "std.index_cast"(%arg0) : ( tensor<index>) -> tensor<i32>
-  // CHECK: standard::index_cast<Tensor<size_t, 2>>(v2)
   %1 = "std.index_cast"(%arg1) : (tensor<2xi32>) -> tensor<2xindex>
-  // CHECK: standard::index_cast<Tensor<size_t, 2, 2>>(v3)
   %2 = "std.index_cast"(%arg2) : (tensor<2x2xi32>) -> tensor<2x2xindex>
-  // CHECK: return v5;
   return %1 : tensor<2xindex>
 }
+// CHECK-LABEL: func @std_index_cast
+//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg0) {template_args = [tensor<i32>]} : (tensor<index>) -> tensor<i32>
+//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg1) {template_args = [tensor<2xindex>]} : (tensor<2xi32>) -> tensor<2xindex>
+//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg2) {template_args = [tensor<2x2xindex>]} : (tensor<2x2xi32>) -> tensor<2x2xindex>
 
-// CHECK: Tensor<float, 8> splat_op(float v1)
+// CPP-LABEL: Tensor<size_t, 2> std_index_cast(Tensor<size_t> v1, Tensor<int32_t, 2> v2, Tensor<int32_t, 2, 2> v3)
+//  CPP-NEXT: standard::index_cast<Tensor<int32_t>>(v1)
+//  CPP-NEXT: standard::index_cast<Tensor<size_t, 2>>(v2)
+//  CPP-NEXT: standard::index_cast<Tensor<size_t, 2, 2>>(v3)
+//  CPP-NEXT: return v5;
+
 func @splat_op(%s : f32) -> tensor<8xf32> {
-  // CHECK: standard::splat<Tensor<float, 8>>(v1)
   %t = splat %s : tensor<8xf32>
   return %t : tensor<8xf32>
 }
+// CHECK-LABEL: func @splat_op
+//  CHECK-NEXT: emitc.call "standard::splat"(%arg0) {template_args = [tensor<8xf32>]} : (f32) -> tensor<8xf32>
+
+// CPP-LABEL: Tensor<float, 8> splat_op(float v1)
+//  CPP-NEXT: standard::splat<Tensor<float, 8>>(v1)
+//  CPP-NEXT: return v2;

--- a/test/Conversion/tensor-to-emitc.mlir
+++ b/test/Conversion/tensor-to-emitc.mlir
@@ -1,14 +1,24 @@
-// RUN: emitc-opt -convert-tensor-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s
+// RUN: emitc-opt -convert-tensor-to-emitc %s | FileCheck %s
+// RUN: emitc-opt -convert-tensor-to-emitc %s | emitc-translate --mlir-to-cpp | FileCheck %s -check-prefix=CPP
 
-// CHECK: void std_extract_element(Tensor<int32_t> v1, Tensor<int32_t, 2> v2)
 func @std_extract_element(%arg0: tensor<i32>, %arg1: tensor<2xi32>) -> () {
   %0 = constant 0 : index
   %1 = constant 1 : index
-  // CHECK: tensor::extract(v1)
   %2 = tensor.extract %arg0[] : tensor<i32>
-  // CHECK: tensor::extract(v2, v3)
   %3 = tensor.extract %arg1[%0] : tensor<2xi32>
-  // CHECK: tensor::extract(v2, v4)
   %4 = tensor.extract %arg1[%1] : tensor<2xi32>
   return 
 }
+// CHECK-LABEL: func @std_extract_element
+//  CHECK-NEXT: constant 0 : index
+//  CHECK-NEXT: constant 1 : index
+//  CHECK-NEXT: emitc.call "tensor::extract"(%arg0) : (tensor<i32>) -> i32
+//  CHECK-NEXT: emitc.call "tensor::extract"(%arg1, %c0) : (tensor<2xi32>, index) -> i32
+//  CHECK-NEXT: emitc.call "tensor::extract"(%arg1, %c1) : (tensor<2xi32>, index) -> i32
+
+// CPP-LABEL: void std_extract_element(Tensor<int32_t> v1, Tensor<int32_t, 2> v2)
+//  CPP-NEXT: size_t v3{0};
+//  CPP-NEXT: size_t v4{1};
+//  CPP-NEXT: tensor::extract(v1)
+//  CPP-NEXT: tensor::extract(v2, v3)
+//  CPP-NEXT: tensor::extract(v2, v4)


### PR DESCRIPTION
We now explicitly check that were piped to emitc-translate before and not checked separately. Furthermore, the MHLO to EmitC tests are expanded (check inputs and outputs as well as arguments and template arguments). The latter also revealed that some non empty template arguments were not checked before.