### PR TITLE
Remove trailing comma from attributes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -98,6 +98,7 @@ jobs:
         python3 ../${EMITC}/scripts/optimize_tf_dialect.py model_tf.mlir model_tf_opt.mlir
         python3 ../${EMITC}/scripts/tf_to_mhlo_dialect.py model_tf_opt.mlir model_mhlo.mlir
         sed "s/tf._input_shapes =.*]//" model_mhlo.mlir > ../${E2E}/model_mhlo_noattr.mlir
+        sed -i "s/, }/}/" ../${E2E}/model_mhlo_noattr.mlir
         python3 ../${EMITC}/scripts/generate_testscases.py --file-format cpp --count 1 --batch-size 2 --seed 1234 mobilenet_v2.h5 ../${E2E}/
 
   build-debug:

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -60,6 +60,7 @@ python tf_to_mhlo_dialect.py "$OUTPUT_DIR"/model_tf_opt.mlir "$OUTPUT_DIR"/model
 
 echo "Removing tf._input_shapes attribute"
 sed "s/tf._input_shapes =.*]//" "$OUTPUT_DIR"/model_mhlo.mlir > "$OUTPUT_DIR"/model_mhlo_noattr.mlir
+sed -i "s/, }/}/" "$OUTPUT_DIR"/model_mhlo_noattr.mlir
 
 echo "Canonicalizing mhlo dialect"
 "$EMITC_OPT" --canonicalize --inline --symbol-dce "$OUTPUT_DIR"/model_mhlo_noattr.mlir > "$OUTPUT_DIR"/model_canon.mlir

--- a/scripts/e2e_test_tosa.sh
+++ b/scripts/e2e_test_tosa.sh
@@ -62,6 +62,7 @@ echo "Converting tf dialect to tosa dialect"
 
 echo "Removing tf._input_shapes attribute"
 sed "s/tf._input_shapes =.*]//" "$OUTPUT_DIR"/model_tosa.mlir > "$OUTPUT_DIR"/model_tosa_noattr.mlir
+sed -i "s/, }/}/" "$OUTPUT_DIR"/model_mhlo_noattr.mlir
 
 echo "Fixing function name"
 FUNCTION_NAME=$(grep -oe "@[^(]*" "$OUTPUT_DIR"/model_tosa_noattr.mlir)


### PR DESCRIPTION
Makes sure to remove if trailing commas are present after stripping
`tf._input_shapes` from the attributes (it might be that it was the last
attribute).