### PR TITLE
Add emitc.getaddressof op to EmitC ops tests

### DIFF
--- a/test/Dialect/EmitC/ops.mlir
+++ b/test/Dialect/EmitC/ops.mlir
@@ -14,3 +14,8 @@ func @c(%arg0: i32) {
   %1 = "emitc.const"(){value = 42 : i32} : () -> i32
   return
 }
+
+func @a(%arg0: i32) {
+  %1 = "emitc.getaddressof"(%arg0) : (i32) -> !emitc.opaque<"int32_t*">
+  return
+}


### PR DESCRIPTION
Till now this was only covered in Target/common-cpp.mlir and was thus
never parsed by emitc-opt.