### PR TITLE
Reorder arguments passed to `add_mlir_doc`

### DIFF
--- a/include/emitc/Dialect/EmitC/CMakeLists.txt
+++ b/include/emitc/Dialect/EmitC/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(EmitC emitc)
-add_mlir_doc(EmitC -gen-dialect-doc EmitC Dialects/)
+add_mlir_doc(EmitC EmitC Dialects/ -gen-dialect-doc)
 
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name EmitC)


### PR DESCRIPTION
The `add_mlir_doc` CMake macro has changed upstream with commit
llvm/llvm-project@90ae4d90.