### PR TITLE
Drop GetAddressOfOp in favor of ApplyOp

### DIFF
--- a/docs/EmitC.md
+++ b/docs/EmitC.md
@@ -18,6 +18,38 @@ Examples:
 
 ## Operation definition
 
+### `emitc.apply` (::mlir::emitc::ApplyOp)
+
+apply operation
+
+
+Syntax:
+
+```
+operation ::= `emitc.apply` $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
+```
+
+With the "apply" operation the operators & (address of) and * (contents of)
+can be applied to a single operand.
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`applicableOperator` | ::mlir::StringAttr | string attribute
+
+#### Operands:
+
+| Operand | Description |
+| :-----: | ----------- |
+`operand` | any type
+
+#### Results:
+
+| Result | Description |
+| :----: | ----------- |
+`result` | any type
+
 ### `emitc.call` (::mlir::emitc::CallOp)
 
 call operation
@@ -177,24 +209,6 @@ func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 | Result | Description |
 | :----: | ----------- |
 `results` | any type
-
-### `emitc.getaddressof` (::mlir::emitc::GetAddressOfOp)
-
-get address of operation
-
-The "getaddressof" operation gets the address via the & operator in C++.
-
-#### Operands:
-
-| Operand | Description |
-| :-----: | ----------- |
-`operand` | any type
-
-#### Results:
-
-| Result | Description |
-| :----: | ----------- |
-`result` | An opaque type
 
 ### `emitc.if` (::mlir::emitc::IfOp)
 

--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -79,6 +79,22 @@ def OpaqueType : EmitC_Type<"Opaque"> {
 class EmitC_Op<string mnemonic, list<OpTrait> traits = []> :
     Op<EmitC_Dialect, mnemonic, traits>;
 
+def EmitC_ApplyOp : EmitC_Op<"apply", []> {
+  let summary = "apply operation";
+  let description = [{
+    With the "apply" operation the operators & (address of) and * (contents of)
+    can be applied to a single operand.
+  }];
+  let arguments = (ins
+    Arg<StrAttr, "the operator to apply">:$applicableOperator,
+    AnyType:$operand);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = [{
+    $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
+  }];
+  let verifier = [{ return ::verify(*this); }];
+}
+
 def EmitC_CallOp : EmitC_Op<"call", []> {
   let summary = "call operation";
   let description = [{
@@ -115,15 +131,6 @@ def EmitC_ConstOp : EmitC_Op<"const", [ConstantLike, NoSideEffect]> {
   let verifier = [{ return ::verify(*this); }];
 
   let hasFolder = 1;
-}
-
-def EmitC_GetAddressOfOp : EmitC_Op<"getaddressof", []> {
-  let summary = "get address of operation";
-  let description = [{
-    The "getaddressof" operation gets the address via the & operator in C++.
-  }];
-  let arguments = (ins AnyType:$operand);
-  let results = (outs OpaqueType:$result);
 }
 
 def EmitC_ForOp : EmitC_Op<"for",

--- a/lib/Dialect/EmitC/IR/EmitCDialect.cpp
+++ b/lib/Dialect/EmitC/IR/EmitCDialect.cpp
@@ -51,6 +51,25 @@ void emitc::buildTerminatedBody(OpBuilder &builder, Location loc) {
 }
 
 //===----------------------------------------------------------------------===//
+// ApplyOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verify(mlir::emitc::ApplyOp op) {
+  StringRef applicableOperator = op.applicableOperator();
+
+  // Applicable operator must not be empty.
+  if (applicableOperator.empty()) {
+    return op.emitOpError("applicable operator must not be empty");
+  }
+
+  // Only `*` and `&` are supported.
+  if (!applicableOperator.equals("&") && !applicableOperator.equals("*"))
+    return op.emitOpError("applicable operator is illegal");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CallOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -220,15 +220,14 @@ static LogicalResult printCallOp(CppEmitter &emitter, emitc::CallOp callOp) {
   return success();
 }
 
-static LogicalResult printGetAddressOfOp(CppEmitter &emitter,
-                                         emitc::GetAddressOfOp getAddressOfOp) {
+static LogicalResult printApplyOp(CppEmitter &emitter, emitc::ApplyOp applyOp) {
   auto &os = emitter.ostream();
-  auto &op = *getAddressOfOp.getOperation();
+  auto &op = *applyOp.getOperation();
 
   if (failed(emitter.emitAssignPrefix(op)))
     return failure();
-  os << "&";
-  os << emitter.getOrCreateName(getAddressOfOp.getOperand());
+  os << applyOp.applicableOperator();
+  os << emitter.getOrCreateName(applyOp.getOperand());
 
   return success();
 }
@@ -773,14 +772,14 @@ LogicalResult CppEmitter::emitLabel(Block &block) {
 
 static LogicalResult printOperation(CppEmitter &emitter, Operation &op) {
   // EmitC ops.
+  if (auto applyOp = dyn_cast<emitc::ApplyOp>(op))
+    return printApplyOp(emitter, applyOp);
   if (auto callOp = dyn_cast<emitc::CallOp>(op))
     return printCallOp(emitter, callOp);
   if (auto constOp = dyn_cast<emitc::ConstOp>(op))
     return printConstantOp(emitter, constOp);
   if (auto forOp = dyn_cast<emitc::ForOp>(op))
     return printForOp(emitter, forOp);
-  if (auto getAdressOfOp = dyn_cast<emitc::GetAddressOfOp>(op))
-    return printGetAddressOfOp(emitter, getAdressOfOp);
   if (auto ifOp = dyn_cast<emitc::IfOp>(op))
     return printIfOp(emitter, ifOp);
   if (auto yieldOp = dyn_cast<emitc::YieldOp>(op))

--- a/test/Dialect/EmitC/invalid_ops.mlir
+++ b/test/Dialect/EmitC/invalid_ops.mlir
@@ -69,3 +69,19 @@ func @dense_template_argument(%arg : i32) {
     emitc.call "dense_template_argument"(%arg) {template_args = [dense<[1.0, 1.0]> : tensor<2xf32>]} : (i32) -> i32
     return
 }
+
+// -----
+
+func @empty_operator(%arg : i32) {
+    // expected-error @+1 {{'emitc.apply' op applicable operator must not be empty}}
+    %2 = emitc.apply ""(%arg) : (i32) -> !emitc.opaque<"int32_t*">
+    return
+}
+
+// -----
+
+func @illegal_operator(%arg : i32) {
+    // expected-error @+1 {{'emitc.apply' op applicable operator is illegal}}
+    %2 = emitc.apply "+"(%arg) : (i32) -> !emitc.opaque<"int32_t*">
+    return
+}

--- a/test/Dialect/EmitC/ops.mlir
+++ b/test/Dialect/EmitC/ops.mlir
@@ -15,7 +15,8 @@ func @c(%arg0: i32) {
   return
 }
 
-func @a(%arg0: i32) {
-  %1 = "emitc.getaddressof"(%arg0) : (i32) -> !emitc.opaque<"int32_t*">
+func @a(%arg0: i32, %arg1: i32) {
+  %1 = "emitc.apply"(%arg0) {applicableOperator = "&"} : (i32) -> !emitc.opaque<"int32_t*">
+  %2 = emitc.apply "&"(%arg1) : (i32) -> !emitc.opaque<"int32_t*">
   return
 }

--- a/test/Target/common-cpp.mlir
+++ b/test/Target/common-cpp.mlir
@@ -77,9 +77,11 @@ func @opaque_types(%arg0: !emitc.opaque<"bool">, %arg1: !emitc.opaque<"char">) -
   return %2 : !emitc.opaque<"status_t">
 }
 
-func @get_address_of(%arg0: i32) -> !emitc.opaque<"int32_t*"> {
+func @apply(%arg0: i32) -> !emitc.opaque<"int32_t*"> {
   // CHECK: int32_t* [[V2]] = &[[V1]];
-  %0 = "emitc.getaddressof" (%arg0) : (i32) -> !emitc.opaque<"int32_t*">
+  %0 = emitc.apply "&"(%arg0) : (i32) -> !emitc.opaque<"int32_t*">
+  // CHECK: int32_t [[V3]] = *[[V2]];
+  %1 = emitc.apply "*"(%0) : (!emitc.opaque<"int32_t*">) -> (i32)
   return %0 : !emitc.opaque<"int32_t*">
 }
 


### PR DESCRIPTION
This replaces the `emitc.getaddressof` op in favor of the newly added
`emitc.apply`. The `emitc.apply` op allows to specify the operator to
apply (the applicable operator). This not only allows a "get address"
using the & operator, as it also enables a "get content" via the *
operator.