### PR TITLE
Move dialect specific namespaces into `emitc`

### DIFF
--- a/include/emitc/emitc_mhlo.h
+++ b/include/emitc/emitc_mhlo.h
@@ -27,6 +27,7 @@
 
 #include "emitc_core_ops.h"
 
+namespace emitc {
 namespace mhlo {
 /// See
 /// https://github.com/tensorflow/tensorflow/blob/6f59650012f8904745dffaba540afc794c6613be/tensorflow/compiler/xla/service/hlo_evaluator.cc
@@ -822,5 +823,6 @@ Dest dot(Lhs lhs, Rhs rhs) {
 }
 
 } // namespace mhlo
+} // namespace emitc
 
 #endif // EMITC_EMITC_MHLO_H

--- a/include/emitc/emitc_std.h
+++ b/include/emitc/emitc_std.h
@@ -19,6 +19,7 @@
 
 #include "emitc_types.h"
 
+namespace emitc {
 namespace standard {
 
 // IndexCastOp
@@ -43,5 +44,6 @@ inline Dest splat(Src x) {
 }
 
 } // namespace standard
+} // namespace emitc
 
 #endif // EMITC_EMITC_STD_H

--- a/include/emitc/emitc_tensor.h
+++ b/include/emitc/emitc_tensor.h
@@ -17,6 +17,7 @@
 
 #include "emitc_types.h"
 
+namespace emitc {
 namespace tensor {
 
 // ExtractOp
@@ -26,5 +27,6 @@ inline T extract(Tensor<T, Shape...> x, Indices... indices) {
 }
 
 } // namespace tensor
+} // namespace emitc
 
 #endif // EMITC_EMITC_TENSOR_H

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -20,6 +20,7 @@
 #include "emitc_core_ops.h"
 #include "emitc_std.h"
 
+namespace emitc {
 namespace tosa {
 
 /// Functions for unary elementwise TOSA ops.
@@ -568,5 +569,6 @@ inline Dest transpose(Src input, Tensor1D<int32_t, Src::rank()> perms) {
 }
 
 } // namespace tosa
+} // namespace emitc
 
 #endif // EMITC_EMITC_TOSA_H

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -495,7 +495,7 @@ Dest slice(Src x, Tensor<int64_t, Src::rank()> start_indices,
   Tensor<int64_t, Src::rank()> limit_indices =
       emitc::add(start_indices, slice_sizes);
   Tensor<int64_t, Src::rank()> strides =
-      standard::splat<Tensor<int64_t, Src::rank()>>(1);
+      emitc::standard::splat<Tensor<int64_t, Src::rank()>>(1);
   return emitc::slice<Dest, Src>(x, start_indices, limit_indices, strides);
 }
 

--- a/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
@@ -155,7 +155,7 @@ private:
 
     auto operands = op.getOperands();
 
-    StringRef funcName = "mhlo::reduce";
+    StringRef funcName = "emitc::mhlo::reduce";
     StringAttr callee = StringAttr::get(ctx, funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -190,7 +190,7 @@ private:
 
     auto operands = op.getOperands();
 
-    StringRef funcName = "mhlo::reduce_window";
+    StringRef funcName = "emitc::mhlo::reduce_window";
     StringAttr callee = StringAttr::get(ctx, funcName);
 
     SmallVector<Attribute, 2> args_ = indexSequence(operands.size(), ctx);

--- a/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
@@ -68,7 +68,7 @@ private:
                   ConversionPatternRewriter &rewriter) const override {
     typename mhlo::BatchNormInferenceOp::Adaptor adaptor(operands);
 
-    StringRef funcName = "mhlo::batch_norm_inference";
+    StringRef funcName = "emitc::mhlo::batch_norm_inference";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -102,7 +102,7 @@ private:
   matchAndRewrite(mhlo::BroadcastInDimOp broadcastInDimOp,
                   ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringRef funcName = "mhlo::broadcast_in_dim";
+    StringRef funcName = "emitc::mhlo::broadcast_in_dim";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -135,7 +135,7 @@ private:
   matchAndRewrite(mhlo::ConcatenateOp concatenateOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
 
-    StringRef funcName = "mhlo::concatenate";
+    StringRef funcName = "emitc::mhlo::concatenate";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     ArrayAttr args;
@@ -164,7 +164,7 @@ private:
     typename mhlo::ConvOp::Adaptor adaptor(operands);
     auto ctx = convOp.getContext();
 
-    StringRef funcName = "mhlo::convolution";
+    StringRef funcName = "emitc::mhlo::convolution";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -268,7 +268,7 @@ private:
   LogicalResult
   matchAndRewrite(mhlo::CompareOp compareOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("mhlo::compare");
+    StringAttr callee = rewriter.getStringAttr("emitc::mhlo::compare");
 
     StringRef comparisonDirection = compareOp.comparison_direction();
     Optional<StringRef> functionName =
@@ -339,7 +339,7 @@ private:
   LogicalResult
   matchAndRewrite(mhlo::SliceOp sliceOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringRef funcName = "mhlo::slice";
+    StringRef funcName = "emitc::mhlo::slice";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -373,7 +373,7 @@ private:
   LogicalResult
   matchAndRewrite(mhlo::DynamicSliceOp dynamicSliceOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringRef funcName = "mhlo::dynamic_slice";
+    StringRef funcName = "emitc::mhlo::dynamic_slice";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_ =
@@ -410,7 +410,7 @@ private:
                   ConversionPatternRewriter &rewriter) const override {
     typename mhlo::DynamicUpdateSliceOp::Adaptor adaptor(operands);
 
-    StringRef funcName = "mhlo::dynamic_update_slice";
+    StringRef funcName = "emitc::mhlo::dynamic_update_slice";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     ArrayAttr args;
@@ -436,7 +436,7 @@ private:
   LogicalResult
   matchAndRewrite(mhlo::PadOp padOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("mhlo::pad");
+    StringAttr callee = rewriter.getStringAttr("emitc::mhlo::pad");
 
     SmallVector<Attribute, 2> args_ =
         indexSequence(operands.size(), padOp.getContext());
@@ -471,7 +471,7 @@ private:
   matchAndRewrite(mhlo::RngBitGeneratorOp rngBitGeneratorOp,
                   ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringRef funcName = "mhlo::rng_bit_generator";
+    StringRef funcName = "emitc::mhlo::rng_bit_generator";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     ArrayAttr args;
@@ -495,40 +495,45 @@ void populateMhloToEmitcPatterns(MLIRContext *ctx,
   patterns.insert<ConstOpConversion>(ctx);
 
   // Insert patterns for MHLO unary elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::AbsOp>>(ctx, "mhlo::abs");
-  patterns.insert<CallOpConversion<mhlo::CeilOp>>(ctx, "mhlo::ceil");
+  patterns.insert<CallOpConversion<mhlo::AbsOp>>(ctx, "emitc::mhlo::abs");
+  patterns.insert<CallOpConversion<mhlo::CeilOp>>(ctx, "emitc::mhlo::ceil");
   patterns.insert<CallOpConversion<mhlo::ConvertOp>>(
-      ctx, "mhlo::convert", /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<mhlo::CosOp>>(ctx, "mhlo::cos");
-  patterns.insert<CallOpConversion<mhlo::ExpOp>>(ctx, "mhlo::exponential");
+      ctx, "emitc::mhlo::convert", /*explicitResultType=*/true);
+  patterns.insert<CallOpConversion<mhlo::CosOp>>(ctx, "emitc::mhlo::cos");
+  patterns.insert<CallOpConversion<mhlo::ExpOp>>(ctx,
+                                                 "emitc::mhlo::exponential");
   patterns.insert<CallOpConversion<mhlo::Expm1Op>>(
-      ctx, "mhlo::exponential_minus_one");
-  patterns.insert<CallOpConversion<mhlo::FloorOp>>(ctx, "mhlo::floor");
-  patterns.insert<CallOpConversion<mhlo::IsFiniteOp>>(ctx, "mhlo::is_finite");
-  patterns.insert<CallOpConversion<mhlo::LogOp>>(ctx, "mhlo::log");
-  patterns.insert<CallOpConversion<mhlo::Log1pOp>>(ctx, "mhlo::log_plus_one");
-  patterns.insert<CallOpConversion<mhlo::NegOp>>(ctx, "mhlo::negate");
-  patterns.insert<CallOpConversion<mhlo::RoundOp>>(ctx, "mhlo::round");
-  patterns.insert<CallOpConversion<mhlo::SinOp>>(ctx, "mhlo::sin");
-  patterns.insert<CallOpConversion<mhlo::SqrtOp>>(ctx, "mhlo::sqrt");
-  patterns.insert<CallOpConversion<mhlo::TanhOp>>(ctx, "mhlo::tanh");
+      ctx, "emitc::mhlo::exponential_minus_one");
+  patterns.insert<CallOpConversion<mhlo::FloorOp>>(ctx, "emitc::mhlo::floor");
+  patterns.insert<CallOpConversion<mhlo::IsFiniteOp>>(ctx,
+                                                      "emitc::mhlo::is_finite");
+  patterns.insert<CallOpConversion<mhlo::LogOp>>(ctx, "emitc::mhlo::log");
+  patterns.insert<CallOpConversion<mhlo::Log1pOp>>(ctx,
+                                                   "emitc::mhlo::log_plus_one");
+  patterns.insert<CallOpConversion<mhlo::NegOp>>(ctx, "emitc::mhlo::negate");
+  patterns.insert<CallOpConversion<mhlo::RoundOp>>(ctx, "emitc::mhlo::round");
+  patterns.insert<CallOpConversion<mhlo::SinOp>>(ctx, "emitc::mhlo::sin");
+  patterns.insert<CallOpConversion<mhlo::SqrtOp>>(ctx, "emitc::mhlo::sqrt");
+  patterns.insert<CallOpConversion<mhlo::TanhOp>>(ctx, "emitc::mhlo::tanh");
 
   // Insert patterns for MHLO binary elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::AddOp>>(ctx, "mhlo::add");
-  patterns.insert<CallOpConversion<mhlo::Atan2Op>>(ctx, "mhlo::atan2");
-  patterns.insert<CallOpConversion<mhlo::DivOp>>(ctx, "mhlo::div");
-  patterns.insert<CallOpConversion<mhlo::MaxOp>>(ctx, "mhlo::max");
-  patterns.insert<CallOpConversion<mhlo::MinOp>>(ctx, "mhlo::min");
-  patterns.insert<CallOpConversion<mhlo::MulOp>>(ctx, "mhlo::mul");
-  patterns.insert<CallOpConversion<mhlo::PowOp>>(ctx, "mhlo::pow");
-  patterns.insert<CallOpConversion<mhlo::ShiftLeftOp>>(ctx, "mhlo::shift_left");
+  patterns.insert<CallOpConversion<mhlo::AddOp>>(ctx, "emitc::mhlo::add");
+  patterns.insert<CallOpConversion<mhlo::Atan2Op>>(ctx, "emitc::mhlo::atan2");
+  patterns.insert<CallOpConversion<mhlo::DivOp>>(ctx, "emitc::mhlo::div");
+  patterns.insert<CallOpConversion<mhlo::MaxOp>>(ctx, "emitc::mhlo::max");
+  patterns.insert<CallOpConversion<mhlo::MinOp>>(ctx, "emitc::mhlo::min");
+  patterns.insert<CallOpConversion<mhlo::MulOp>>(ctx, "emitc::mhlo::mul");
+  patterns.insert<CallOpConversion<mhlo::PowOp>>(ctx, "emitc::mhlo::pow");
+  patterns.insert<CallOpConversion<mhlo::ShiftLeftOp>>(
+      ctx, "emitc::mhlo::shift_left");
   patterns.insert<CallOpConversion<mhlo::ShiftRightLogicalOp>>(
-      ctx, "mhlo::shift_right_logical");
-  patterns.insert<CallOpConversion<mhlo::SubOp>>(ctx, "mhlo::sub");
+      ctx, "emitc::mhlo::shift_right_logical");
+  patterns.insert<CallOpConversion<mhlo::SubOp>>(ctx, "emitc::mhlo::sub");
 
   // Insert patterns for MHLO binary logical elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::OrOp>>(ctx, "mhlo::logical_or");
-  patterns.insert<CallOpConversion<mhlo::XorOp>>(ctx, "mhlo::logical_xor");
+  patterns.insert<CallOpConversion<mhlo::OrOp>>(ctx, "emitc::mhlo::logical_or");
+  patterns.insert<CallOpConversion<mhlo::XorOp>>(ctx,
+                                                 "emitc::mhlo::logical_xor");
 
   // Insert patterns for MHLO tuple ops.
   patterns.insert<CompareOpConversion>(ctx);
@@ -543,23 +548,23 @@ void populateMhloToEmitcPatterns(MLIRContext *ctx,
   // Insert patterns for other MHLO ops.
   patterns.insert<BatchNormInferenceOpConversion>(ctx);
   patterns.insert<CallOpConversion<mhlo::BitcastConvertOp>>(
-      ctx, "mhlo::bitcast_convert", /*explicitResultType=*/true);
+      ctx, "emitc::mhlo::bitcast_convert", /*explicitResultType=*/true);
   patterns.insert<BroadcastInDimOpConversion>(ctx);
   patterns.insert<CallOpConversion<mhlo::ClampOp>>(
-      ctx, "mhlo::clamp", /*explicitResultType=*/false,
+      ctx, "emitc::mhlo::clamp", /*explicitResultType=*/false,
       /*explicitOperandTypes=*/true);
   patterns.insert<ConcatenateOpConversion>(ctx);
   patterns.insert<ConvOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::DotOp>>(ctx, "mhlo::dot",
+  patterns.insert<CallOpConversion<mhlo::DotOp>>(ctx, "emitc::mhlo::dot",
                                                  /*explicitResultType=*/true);
   patterns.insert<PadOpConversion>(ctx);
   patterns.insert<CallOpConversion<mhlo::ReshapeOp>>(
-      ctx, "mhlo::reshape", /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<mhlo::SelectOp>>(ctx, "mhlo::select");
+      ctx, "emitc::mhlo::reshape", /*explicitResultType=*/true);
+  patterns.insert<CallOpConversion<mhlo::SelectOp>>(ctx, "emitc::mhlo::select");
 
   // Insert patterns for MHLO RNG ops.
   patterns.insert<CallOpConversion<mhlo::RngUniformOp>>(
-      ctx, "mhlo::rng_uniform", /*explicitResultType=*/true);
+      ctx, "emitc::mhlo::rng_uniform", /*explicitResultType=*/true);
   patterns.insert<RngBitGeneratorOpConversion>(ctx);
 }
 

--- a/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
@@ -36,7 +36,7 @@ private:
   LogicalResult
   matchAndRewrite(IndexCastOp indexCastOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("standard::index_cast");
+    StringAttr callee = rewriter.getStringAttr("emitc::standard::index_cast");
 
     ArrayAttr args;
     Type resultType = indexCastOp.getResult().getType();
@@ -61,7 +61,7 @@ private:
   LogicalResult
   matchAndRewrite(SplatOp splatOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("standard::splat");
+    StringAttr callee = rewriter.getStringAttr("emitc::standard::splat");
 
     ArrayAttr args;
     Type resultType = splatOp.getResult().getType();

--- a/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
@@ -37,7 +37,7 @@ private:
   LogicalResult
   matchAndRewrite(mlir::tensor::ExtractOp indexCastOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("tensor::extract");
+    StringAttr callee = rewriter.getStringAttr("emitc::tensor::extract");
 
     Type elementType = indexCastOp.getType();
     if (auto tensorType = elementType.dyn_cast<TensorType>()) {

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -189,7 +189,7 @@ private:
           "Quantization of tosa.fully_connected is currently not supported.");
     }
 
-    StringRef funcName = "tosa::fully_connected";
+    StringRef funcName = "emitc::tosa::fully_connected";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     Type type = fullyConnectedOp.getType();
@@ -221,7 +221,7 @@ private:
           "Quantization of tosa.matmul is currently not supported.");
     }
 
-    StringRef funcName = "tosa::matmul";
+    StringRef funcName = "emitc::tosa::matmul";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     ArrayAttr args;
@@ -246,7 +246,7 @@ private:
   matchAndRewrite(tosa::ClampOp clampOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
 
-    StringRef funcName = "tosa::clamp";
+    StringRef funcName = "emitc::tosa::clamp";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_;
@@ -301,7 +301,7 @@ private:
           "Quantization of tosa.negate is currently not supported.");
     }
 
-    StringRef funcName = "tosa::negate";
+    StringRef funcName = "emitc::tosa::negate";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     ArrayAttr args;
@@ -326,7 +326,7 @@ private:
   matchAndRewrite(tosa::ReluNOp reluNOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
 
-    StringRef funcName = "tosa::reluN";
+    StringRef funcName = "emitc::tosa::reluN";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     SmallVector<Attribute, 2> args_;
@@ -384,7 +384,7 @@ private:
         operands);
 
     // Create reciprocal op.
-    StringRef reciprocalFuncName = "tosa::reciprocal";
+    StringRef reciprocalFuncName = "emitc::tosa::reciprocal";
     StringAttr reciprocalCallee = rewriter.getStringAttr(reciprocalFuncName);
 
     auto reciprocalOp = rewriter.create<emitc::CallOp>(
@@ -523,7 +523,7 @@ private:
   LogicalResult
   matchAndRewrite(tosa::MulOp mulOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringRef funcName = "tosa::mul";
+    StringRef funcName = "emitc::tosa::mul";
     StringAttr callee = rewriter.getStringAttr(funcName);
 
     auto shiftAttr = mulOp.shiftAttr();
@@ -631,7 +631,7 @@ private:
           "Quantization of tosa.pad is currently not supported.");
     }
 
-    StringAttr callee = rewriter.getStringAttr("tosa::pad");
+    StringAttr callee = rewriter.getStringAttr("emitc::tosa::pad");
 
     // No arguments! Pad itself is an operand and not an argument. Therefore, we
     // have to handle any conversion in tosa::pad.
@@ -659,7 +659,7 @@ private:
   LogicalResult
   matchAndRewrite(tosa::SliceOp sliceOp, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    StringAttr callee = rewriter.getStringAttr("tosa::slice");
+    StringAttr callee = rewriter.getStringAttr("emitc::tosa::slice");
 
     // clang-format off
     ArrayAttr args = rewriter.getArrayAttr({
@@ -687,55 +687,60 @@ void populateTosaToEmitcPatterns(MLIRContext *ctx,
   patterns.insert<ConstOpConversion>(ctx);
 
   // Insert patterns for TOSA unary elementwise ops.
-  patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "tosa::abs");
-  patterns.insert<CallOpConversion<tosa::CastOp>>(ctx, "tosa::cast",
+  patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "emitc::tosa::abs");
+  patterns.insert<CallOpConversion<tosa::CastOp>>(ctx, "emitc::tosa::cast",
                                                   /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<tosa::CeilOp>>(ctx, "tosa::ceil");
+  patterns.insert<CallOpConversion<tosa::CeilOp>>(ctx, "emitc::tosa::ceil");
   patterns.insert<ClampOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "tosa::exp");
-  patterns.insert<CallOpConversion<tosa::FloorOp>>(ctx, "tosa::floor");
-  patterns.insert<CallOpConversion<tosa::LogOp>>(ctx, "tosa::log");
+  patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "emitc::tosa::exp");
+  patterns.insert<CallOpConversion<tosa::FloorOp>>(ctx, "emitc::tosa::floor");
+  patterns.insert<CallOpConversion<tosa::LogOp>>(ctx, "emitc::tosa::log");
   patterns.insert<NegateOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::ReciprocalOp>>(ctx,
-                                                        "tosa::reciprocal");
+  patterns.insert<CallOpConversion<tosa::ReciprocalOp>>(
+      ctx, "emitc::tosa::reciprocal");
   patterns.insert<ReluNOpConversion>(ctx);
   patterns.insert<RsqrtOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::TanhOp>>(ctx, "tosa::tanh");
+  patterns.insert<CallOpConversion<tosa::TanhOp>>(ctx, "emitc::tosa::tanh");
 
   // Insert patterns for TOSA binary elementwise ops.
-  patterns.insert<CallOpBroadcastableConversion<tosa::AddOp>>(ctx, "tosa::add");
+  patterns.insert<CallOpBroadcastableConversion<tosa::AddOp>>(
+      ctx, "emitc::tosa::add");
   patterns.insert<CallOpBroadcastableConversion<tosa::MaximumOp>>(
-      ctx, "tosa::maximum");
+      ctx, "emitc::tosa::maximum");
   patterns.insert<CallOpBroadcastableConversion<tosa::MinimumOp>>(
-      ctx, "tosa::minimum");
-  patterns.insert<MulOpConversion>(ctx, "tosa::mul");
-  patterns.insert<CallOpBroadcastableConversion<tosa::PowOp>>(ctx, "tosa::pow");
-  patterns.insert<CallOpBroadcastableConversion<tosa::SubOp>>(ctx, "tosa::sub");
+      ctx, "emitc::tosa::minimum");
+  patterns.insert<MulOpConversion>(ctx, "emitc::tosa::mul");
+  patterns.insert<CallOpBroadcastableConversion<tosa::PowOp>>(
+      ctx, "emitc::tosa::pow");
+  patterns.insert<CallOpBroadcastableConversion<tosa::SubOp>>(
+      ctx, "emitc::tosa::sub");
 
   // Insert patterns for other TOSA ops.
-  patterns.insert<GenericConvOpConversion<tosa::Conv2DOp>>(ctx, "tosa::conv2d");
+  patterns.insert<GenericConvOpConversion<tosa::Conv2DOp>>(
+      ctx, "emitc::tosa::conv2d");
   patterns.insert<GenericConvOpConversion<tosa::DepthwiseConv2DOp>>(
-      ctx, "tosa::depthwise_conv2d");
-  patterns.insert<FullyConnectedOpConversion>(ctx, "tosa::fully_connected");
+      ctx, "emitc::tosa::depthwise_conv2d");
+  patterns.insert<FullyConnectedOpConversion>(ctx,
+                                              "emitc::tosa::fully_connected");
   patterns.insert<MatMulOpConversion>(ctx);
-  patterns.insert<ReduceOpConversion<tosa::ReduceAllOp>>(ctx,
-                                                         "tosa::reduce_all");
-  patterns.insert<ReduceOpConversion<tosa::ReduceAnyOp>>(ctx,
-                                                         "tosa::reduce_any");
-  patterns.insert<ReduceOpConversion<tosa::ReduceMaxOp>>(ctx,
-                                                         "tosa::reduce_max");
-  patterns.insert<ReduceOpConversion<tosa::ReduceMinOp>>(ctx,
-                                                         "tosa::reduce_min");
-  patterns.insert<ReduceOpConversion<tosa::ReduceProdOp>>(ctx,
-                                                          "tosa::reduce_prod");
-  patterns.insert<ReduceOpConversion<tosa::ReduceSumOp>>(ctx,
-                                                         "tosa::reduce_sum");
+  patterns.insert<ReduceOpConversion<tosa::ReduceAllOp>>(
+      ctx, "emitc::tosa::reduce_all");
+  patterns.insert<ReduceOpConversion<tosa::ReduceAnyOp>>(
+      ctx, "emitc::tosa::reduce_any");
+  patterns.insert<ReduceOpConversion<tosa::ReduceMaxOp>>(
+      ctx, "emitc::tosa::reduce_max");
+  patterns.insert<ReduceOpConversion<tosa::ReduceMinOp>>(
+      ctx, "emitc::tosa::reduce_min");
+  patterns.insert<ReduceOpConversion<tosa::ReduceProdOp>>(
+      ctx, "emitc::tosa::reduce_prod");
+  patterns.insert<ReduceOpConversion<tosa::ReduceSumOp>>(
+      ctx, "emitc::tosa::reduce_sum");
   patterns.insert<CallOpConversion<tosa::ReshapeOp>>(
-      ctx, "tosa::reshape", /*explicitResultType=*/true);
+      ctx, "emitc::tosa::reshape", /*explicitResultType=*/true);
   patterns.insert<SliceOpConversion>(ctx);
   patterns.insert<PadOpConversion>(ctx);
   patterns.insert<CallOpConversion<tosa::TransposeOp>>(
-      ctx, "tosa::transpose", /*explicitResultType=*/true);
+      ctx, "emitc::tosa::transpose", /*explicitResultType=*/true);
 }
 
 namespace {

--- a/test/Conversion/mhlo-to-emitc.mlir
+++ b/test/Conversion/mhlo-to-emitc.mlir
@@ -12,91 +12,91 @@ func @mhlo_constant(%arg0: tensor<2xi32>) -> tensor<2xi32> {
 // Unary elementwise ops
 
 func @float_abs(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_ceil(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::ceil"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::ceil"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.ceil"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_convert(%arg0: tensor<ui32>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::convert"(%arg0) {template_args = [tensor<ui64>]} : (tensor<ui32>) -> tensor<ui64>
+  // CHECK: emitc.call "emitc::mhlo::convert"(%arg0) {template_args = [tensor<ui64>]} : (tensor<ui32>) -> tensor<ui64>
   %0 = "mhlo.convert"(%arg0) : (tensor<ui32>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
 
 func @mhlo_cos(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::cos"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::cos"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.cosine"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_exponential(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::exponential"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::exponential"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.exponential"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_exponential_minus_one(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::exponential_minus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::exponential_minus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.exponential_minus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_floor(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::floor"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::floor"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.floor"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_is_finite(%arg0: tensor<4xf32>) -> tensor<4xi1> {
-  // CHECK: emitc.call "mhlo::is_finite"(%arg0) : (tensor<4xf32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::is_finite"(%arg0) : (tensor<4xf32>) -> tensor<4xi1>
   %0 = "mhlo.is_finite"(%arg0) : (tensor<4xf32>) -> tensor<4xi1>
   return %0 : tensor<4xi1>
 }
 
 func @mhlo_log(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::log"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::log"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.log"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_log_plus_one(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::log_plus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::log_plus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.log_plus_one"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_negate(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::negate"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::negate"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.negate"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_round(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::round"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::round"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.round_nearest_afz"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_sine(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::sin"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::sin"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.sine"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_sqrt(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::sqrt"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::sqrt"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.sqrt"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_tanh(%arg0: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::tanh"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::tanh"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   %0 = "mhlo.tanh"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
@@ -105,67 +105,67 @@ func @mhlo_tanh(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 // Binary elementwise ops
 
 func @mhlo_add_i64(%arg0: tensor<i64>) -> tensor<i64> {
-  // CHECK: emitc.call "mhlo::add"(%arg0, %arg0) : (tensor<i64>, tensor<i64>) -> tensor<i64>
+  // CHECK: emitc.call "emitc::mhlo::add"(%arg0, %arg0) : (tensor<i64>, tensor<i64>) -> tensor<i64>
   %0 = mhlo.add %arg0, %arg0 : tensor<i64>
   return %0 : tensor<i64>
 }
 
 func @mhlo_add_f64(%arg0: tensor<f64>) -> tensor<f64> {
-  // CHECK: emitc.call "mhlo::add"(%arg0, %arg0) : (tensor<f64>, tensor<f64>) -> tensor<f64>
+  // CHECK: emitc.call "emitc::mhlo::add"(%arg0, %arg0) : (tensor<f64>, tensor<f64>) -> tensor<f64>
   %0 = mhlo.add %arg0, %arg0 : tensor<f64>
   return %0 : tensor<f64>
 }
 
 func @mhlo_atan2(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::atan2"
+  // CHECK: emitc.call "emitc::mhlo::atan2"
   %0 = "mhlo.atan2"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
 func @mhlo_divide(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::div"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::div"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.divide"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_max(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: emitc.call "mhlo::max"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: emitc.call "emitc::mhlo::max"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   %0 = "mhlo.maximum"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
 func @mhlo_min(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-  // CHECK: emitc.call "mhlo::min"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: emitc.call "emitc::mhlo::min"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   %0 = "mhlo.minimum"(%arg0, %arg0) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 
 func @mhlo_multiply(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::mul"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::mul"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.multiply"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_power(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::pow"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::pow"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.power"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_shift_left(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::shift_left"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::shift_left"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.shift_left"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_shift_right_logical(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::shift_right_logical"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::shift_right_logical"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.shift_right_logical"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
 func @mhlo_sub(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: emitc.call "mhlo::sub"(%arg0, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: emitc.call "emitc::mhlo::sub"(%arg0, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   %0 = "mhlo.subtract"(%arg0, %arg0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
@@ -174,13 +174,13 @@ func @mhlo_sub(%arg0: tensor<f32>) -> tensor<f32> {
 // Binary logical elementwise ops
 
 func @mhlo_or(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::logical_or"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
+  // CHECK: emitc.call "emitc::mhlo::logical_or"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   %0 = "mhlo.or"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
 
 func @mhlo_xor(%arg0: tensor<ui64>, %arg1: tensor<ui64>) -> tensor<ui64> {
-  // CHECK: emitc.call "mhlo::logical_xor"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
+  // CHECK: emitc.call "emitc::mhlo::logical_xor"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   %0 = "mhlo.xor"(%arg0, %arg1) : (tensor<ui64>, tensor<ui64>) -> tensor<ui64>
   return %0 : tensor<ui64>
 }
@@ -218,17 +218,17 @@ func @mhlo_tuple_unpack(%arg0: tensor<i32>, %arg1: tensor<ui64>) -> (tuple<tenso
 }
 
 func @mhlo_compare(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi1> {
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %0 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "LT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::less_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %1 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "LE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %2 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "GT"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::greater_equal"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %3 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "GE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %4 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "EQ"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  // CHECK: emitc.call "mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::not_equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
+  // CHECK: emitc.call "emitc::mhlo::compare"(%arg0, %arg1) {template_args = [tensor<4xi32>, "std::not_equal_to"]} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
   %5 = "mhlo.compare"(%arg0, %arg1) {comparison_direction = "NE"} : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
 
   return %0 : tensor<4xi1>
@@ -238,9 +238,9 @@ func @mhlo_compare(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> tensor<4xi1> {
 // Slice ops
 
 func @mhlo_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -> tensor<4x3xi32> {
-  // CHECK: emitc.call "mhlo::slice"(%arg0) {args = [0 : index, dense<0> : tensor<1xi64>, dense<1> : tensor<1xi64>, dense<1> : tensor<1xi64>], template_args = [tensor<1xi32>]} : (tensor<12xi32>) -> tensor<1xi32>
+  // CHECK: emitc.call "emitc::mhlo::slice"(%arg0) {args = [0 : index, dense<0> : tensor<1xi64>, dense<1> : tensor<1xi64>, dense<1> : tensor<1xi64>], template_args = [tensor<1xi32>]} : (tensor<12xi32>) -> tensor<1xi32>
   %0 = "mhlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<12xi32>) -> tensor<1xi32>
-  // CHECK: emitc.call "mhlo::slice"(%arg1) {args = [0 : index, dense<0> : tensor<2xi64>, dense<[4, 3]> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<4x3xi32>]} : (tensor<8x7xi32>) -> tensor<4x3xi32>
+  // CHECK: emitc.call "emitc::mhlo::slice"(%arg1) {args = [0 : index, dense<0> : tensor<2xi64>, dense<[4, 3]> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<4x3xi32>]} : (tensor<8x7xi32>) -> tensor<4x3xi32>
   %1 = "mhlo.slice"(%arg1) {limit_indices = dense<[4, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x7xi32>) -> tensor<4x3xi32>
   return %1 : tensor<4x3xi32>
 }
@@ -248,9 +248,9 @@ func @mhlo_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -> tensor<4x3xi3
 func @mhlo_dynamic_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -> () {
   %cst = "std.constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
   %cst_0 = "std.constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
-  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg0, %cst) {args = [0 : index, 1 : index, dense<4> : tensor<1xi64>], template_args = [tensor<4xi32>]} : (tensor<12xi32>, tensor<i64>) -> tensor<4xi32>
+  // CHECK: emitc.call "emitc::mhlo::dynamic_slice"(%arg0, %cst) {args = [0 : index, 1 : index, dense<4> : tensor<1xi64>], template_args = [tensor<4xi32>]} : (tensor<12xi32>, tensor<i64>) -> tensor<4xi32>
   %0 = "mhlo.dynamic-slice"(%arg0, %cst) {slice_sizes = dense<4> : tensor<1xi64>} : (tensor<12xi32>, tensor<i64>) -> tensor<4xi32>
-  // CHECK: emitc.call "mhlo::dynamic_slice"(%arg1, %cst, %cst_0) {args = [0 : index, 1 : index, 2 : index, dense<[4, 2]> : tensor<2xi64>], template_args = [tensor<4x2xi32>]} : (tensor<8x7xi32>, tensor<i64>, tensor<i64>) -> tensor<4x2xi32>
+  // CHECK: emitc.call "emitc::mhlo::dynamic_slice"(%arg1, %cst, %cst_0) {args = [0 : index, 1 : index, 2 : index, dense<[4, 2]> : tensor<2xi64>], template_args = [tensor<4x2xi32>]} : (tensor<8x7xi32>, tensor<i64>, tensor<i64>) -> tensor<4x2xi32>
   %1 = "mhlo.dynamic-slice"(%arg1, %cst, %cst_0) {slice_sizes = dense<[4, 2]> : tensor<2xi64>} : (tensor<8x7xi32>, tensor<i64>, tensor<i64>) -> tensor<4x2xi32>
   return
 }
@@ -260,9 +260,9 @@ func @mhlo_dynamic_update_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -
   %cst_0 = "std.constant"() {value = dense<3> : tensor<i64>} : () -> tensor<i64>
   %cst_1 = "std.constant"() {value = dense<1> : tensor<4xi32>} : () -> tensor<4xi32>
   %cst_2 = "std.constant"() {value = dense<1> : tensor<2x4xi32>} : () -> tensor<2x4xi32>
-  // CHECK: emitc.call "mhlo::dynamic_update_slice"(%arg0, %cst_1, %cst) {template_args = [tensor<4xi32>]}
+  // CHECK: emitc.call "emitc::mhlo::dynamic_update_slice"(%arg0, %cst_1, %cst) {template_args = [tensor<4xi32>]}
   %0 = "mhlo.dynamic-update-slice"(%arg0, %cst_1, %cst) : (tensor<12xi32>, tensor<4xi32>, tensor<i64>) -> tensor<12xi32>
-  // CHECK: emitc.call "mhlo::dynamic_update_slice"(%arg1, %cst_2, %cst, %cst_0) {template_args = [tensor<2x4xi32>]}
+  // CHECK: emitc.call "emitc::mhlo::dynamic_update_slice"(%arg1, %cst_2, %cst, %cst_0) {template_args = [tensor<2x4xi32>]}
   %1 = "mhlo.dynamic-update-slice"(%arg1, %cst_2, %cst, %cst_0) : (tensor<8x7xi32>, tensor<2x4xi32>, tensor<i64>, tensor<i64>) -> tensor<8x7xi32>
   return
 }
@@ -271,37 +271,37 @@ func @mhlo_dynamic_update_slice(%arg0: tensor<12xi32>, %arg1: tensor<8x7xi32>) -
 // Other ops
 
 func @mhlo_batch_norm_inference(%arg0: tensor<4x2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xf32>, %arg3: tensor<2xf32>, %arg4: tensor<2xf32>) -> tensor<4x2xf32> {
-  // CHECK: emitc.call "mhlo::batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {args = [0 : index, 1 : index, 2 : index, 3 : index, 4 : index, 1.000000e-03 : f32, 1], template_args = [tensor<4x2xf32>, tensor<2xf32>]} : (tensor<4x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<4x2xf32>
+  // CHECK: emitc.call "emitc::mhlo::batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {args = [0 : index, 1 : index, 2 : index, 3 : index, 4 : index, 1.000000e-03 : f32, 1], template_args = [tensor<4x2xf32>, tensor<2xf32>]} : (tensor<4x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<4x2xf32>
   %0 = "mhlo.batch_norm_inference"(%arg0, %arg1, %arg2, %arg3, %arg4) {epsilon = 0.001 : f32, feature_index = 1 : i64} : (tensor<4x2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>, tensor<2xf32>) -> tensor<4x2xf32>
   return %0 : tensor<4x2xf32>
 }
 
 func @mhlo_bitcast_convert(%arg0: tensor<ui32>) -> tensor<i32> {
-  // CHECK: emitc.call "mhlo::bitcast_convert"(%arg0) {template_args = [tensor<i32>]} : (tensor<ui32>) -> tensor<i32>
+  // CHECK: emitc.call "emitc::mhlo::bitcast_convert"(%arg0) {template_args = [tensor<i32>]} : (tensor<ui32>) -> tensor<i32>
   %0 = "mhlo.bitcast_convert"(%arg0) : (tensor<ui32>) -> tensor<i32>
   return %0 : tensor<i32>
 }
 
 func @mhlo_broadcast_in_dim(%arg0: tensor<i32>) -> tensor<3xi32> {
-  // CHECK: emitc.call "mhlo::broadcast_in_dim"(%arg0) {args = [0 : index, dense<> : tensor<0xi64>], template_args = [tensor<3xi32>]} : (tensor<i32>) -> tensor<3xi32>
+  // CHECK: emitc.call "emitc::mhlo::broadcast_in_dim"(%arg0) {args = [0 : index, dense<> : tensor<0xi64>], template_args = [tensor<3xi32>]} : (tensor<i32>) -> tensor<3xi32>
   %0 = "mhlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<> : tensor<0xi64>} : (tensor<i32>) -> tensor<3xi32>
   return %0 : tensor<3xi32>
 }
 
 func @mhlo_clamp(%arg0: tensor<2x1xf32>, %arg1: tensor<2x1xf32>, %arg2: tensor<2x1xf32>) -> tensor<2x1xf32> {
-  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>]} : (tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<2x1xf32>
+  // CHECK: emitc.call "emitc::mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>]} : (tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<2x1xf32>
   %0 = "mhlo.clamp"(%arg0, %arg1, %arg2) : (tensor<2x1xf32>, tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<2x1xf32>
   return %0 : tensor<2x1xf32>
 }
 
 func @mhlo_clamp_broadcast(%arg0: tensor<i32>, %arg1: tensor<4x2x1xi32>, %arg2: tensor<i32>) -> tensor<4x2x1xi32> {
-  // CHECK: emitc.call "mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<i32>, tensor<4x2x1xi32>, tensor<i32>]} : (tensor<i32>, tensor<4x2x1xi32>, tensor<i32>) -> tensor<4x2x1xi32>
+  // CHECK: emitc.call "emitc::mhlo::clamp"(%arg0, %arg1, %arg2) {template_args = [tensor<i32>, tensor<4x2x1xi32>, tensor<i32>]} : (tensor<i32>, tensor<4x2x1xi32>, tensor<i32>) -> tensor<4x2x1xi32>
   %0 = "mhlo.clamp"(%arg0, %arg1, %arg2) : (tensor<i32>, tensor<4x2x1xi32>, tensor<i32>) -> tensor<4x2x1xi32>
   return %0 : tensor<4x2x1xi32>
 }
 
 func @mhlo_concaternate(%arg0: tensor<1xf32>, %arg1: tensor<2xf32>) -> tensor<3xf32> {
-  // CHECK: emitc.call "mhlo::concatenate"(%arg0, %arg1) {template_args = [0, tensor<3xf32>]} : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
+  // CHECK: emitc.call "emitc::mhlo::concatenate"(%arg0, %arg1) {template_args = [0, tensor<3xf32>]} : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
   %0 = "mhlo.concatenate"(%arg0, %arg1) {dimension = 0 : i64} : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
   return %0 : tensor<3xf32>
 }
@@ -310,7 +310,7 @@ func @mhlo_concaternate(%arg0: tensor<1xf32>, %arg1: tensor<2xf32>) -> tensor<3x
 // https://github.com/tensorflow/mlir-hlo/blob/31c1c3aa1ffa12b1fb2d9988ad8cc0b2de9cd581/tests/hlo-legalize-to-lhlo.mlir#L552-L580
 func @mhlo_conv(%arg0: tensor<3x5x5x3xf32>, %arg1 : tensor<2x2x3x4xf32>) -> tensor<3x5x5x4xf32> {
   %c0 = constant 0 : index
-  // CHECK: emitc.call "mhlo::convolution"(%arg1, %arg0)
+  // CHECK: emitc.call "emitc::mhlo::convolution"(%arg1, %arg0)
   %out = "mhlo.convolution"(%arg1, %arg0) {
     batch_group_count = 1 : i64,
     dimension_numbers = {
@@ -333,13 +333,13 @@ func @mhlo_conv(%arg0: tensor<3x5x5x3xf32>, %arg1 : tensor<2x2x3x4xf32>) -> tens
 }
 
 func @mhlo_dot(%arg0: tensor<512x512xf32>) -> tensor<512x512xf32> {
-  // CHECK: emitc.call "mhlo::dot"(%arg0, %arg0) {template_args = [tensor<512x512xf32>]} : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
+  // CHECK: emitc.call "emitc::mhlo::dot"(%arg0, %arg0) {template_args = [tensor<512x512xf32>]} : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
   %0 = "mhlo.dot"(%arg0, %arg0) : (tensor<512x512xf32>, tensor<512x512xf32>) -> tensor<512x512xf32>
   return %0 : tensor<512x512xf32>
 }
 
 func @mhlo_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<4x7xf32> {
-  // CHECK: emitc.call "mhlo::pad"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<-1> : tensor<2xi64>, dense<1> : tensor<2xi64>, dense<2> : tensor<2xi64>], template_args = [tensor<4x7xf32>]} : (tensor<2x3xf32>, tensor<f32>) -> tensor<4x7xf32>
+  // CHECK: emitc.call "emitc::mhlo::pad"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<-1> : tensor<2xi64>, dense<1> : tensor<2xi64>, dense<2> : tensor<2xi64>], template_args = [tensor<4x7xf32>]} : (tensor<2x3xf32>, tensor<f32>) -> tensor<4x7xf32>
   %0 = "mhlo.pad"(%arg0, %arg1) {
     edge_padding_low = dense<-1> : tensor<2xi64>,
     edge_padding_high = dense<1> : tensor<2xi64>,
@@ -349,14 +349,14 @@ func @mhlo_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<f32>) -> tensor<4x7xf32> {
 }
 
 func @mhlo_reduce(%arg0 : tensor<2x1000xf32>, %arg1 : tensor<f32>, %arg2 : tensor<2x1000xi32>, %arg3 : tensor<i32>) -> tensor<2xi32>{
-  // CHECK: emitc.call "mhlo::reduce"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_0], template_args = [tensor<2xf32>, 1]} : (tensor<2x1000xf32>, tensor<f32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::reduce"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_0], template_args = [tensor<2xf32>, 1]} : (tensor<2x1000xf32>, tensor<f32>) -> tensor<2xf32>
   %0 = "mhlo.reduce"(%arg0, %arg1) ({
     ^bb0(%arg4: tensor<f32>, %arg5: tensor<f32>):
       %1 = mhlo.add %arg4, %arg5 : tensor<f32>
       "mhlo.return"(%1) : (tensor<f32>) -> ()
     }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<2x1000xf32>, tensor<f32>) -> tensor<2xf32>
   
-  // CHECK: emitc.call "mhlo::reduce"(%arg2, %arg3) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_1], template_args = [tensor<2xi32>, 1]} : (tensor<2x1000xi32>, tensor<i32>) -> tensor<2xi32>
+  // CHECK: emitc.call "emitc::mhlo::reduce"(%arg2, %arg3) {args = [0 : index, 1 : index, dense<1> : tensor<1xi64>, @mhlo_reduce_lambda_1], template_args = [tensor<2xi32>, 1]} : (tensor<2x1000xi32>, tensor<i32>) -> tensor<2xi32>
   %1 = "mhlo.reduce"(%arg2, %arg3) ({
     ^bb0(%arg4: tensor<i32>, %arg5: tensor<i32>):
       %2 = mhlo.maximum %arg4, %arg5 : tensor<i32>
@@ -364,13 +364,13 @@ func @mhlo_reduce(%arg0 : tensor<2x1000xf32>, %arg1 : tensor<f32>, %arg2 : tenso
     }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<2x1000xi32>, tensor<i32>) -> tensor<2xi32>
   return %1 : tensor<2xi32>
   // CHECK: func @mhlo_reduce_lambda_0(%arg0: tensor<f32>, %arg1: tensor<f32>)
-  // CHECK: "mhlo::add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  // CHECK: "emitc::mhlo::add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
   // CHECK: func @mhlo_reduce_lambda_1(%arg0: tensor<i32>, %arg1: tensor<i32>)
-  // CHECK: "mhlo::max"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
+  // CHECK: "emitc::mhlo::max"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
 }
 
 func @mhlo_reduce_window(%arg0 : tensor<2x114x114x64xf32>, %arg1 : tensor<f32>) -> tensor<2x56x56x64xf32> {
-  // CHECK: emitc.call "mhlo::reduce_window"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<[1, 3, 3, 1]> : tensor<4xi64>, dense<[1, 2, 2, 1]> : tensor<4xi64>, dense<1> : tensor<4xi64>, dense<1> : tensor<4xi64>, dense<0> : tensor<8xi64>, @mhlo_reduce_window_lambda_0], template_args = [tensor<2x56x56x64xf32>]}
+  // CHECK: emitc.call "emitc::mhlo::reduce_window"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<[1, 3, 3, 1]> : tensor<4xi64>, dense<[1, 2, 2, 1]> : tensor<4xi64>, dense<1> : tensor<4xi64>, dense<1> : tensor<4xi64>, dense<0> : tensor<8xi64>, @mhlo_reduce_window_lambda_0], template_args = [tensor<2x56x56x64xf32>]}
   %0 = "mhlo.reduce_window"(%arg0, %arg1) ( {
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):  // no predecessors
       %516 = mhlo.maximum %arg2, %arg3 : tensor<f32>
@@ -379,17 +379,17 @@ func @mhlo_reduce_window(%arg0 : tensor<2x114x114x64xf32>, %arg1 : tensor<f32>) 
   
   return %0 : tensor<2x56x56x64xf32>
   // CHECK: func @mhlo_reduce_window_lambda_0(%arg0: tensor<f32>, %arg1: tensor<f32>)
-  // CHECK: "mhlo::max"
+  // CHECK: "emitc::mhlo::max"
 }
 
 func @mhlo_reshape(%arg0: tensor<12xf32>) -> tensor<2x3x2xf32> {
-  // CHECK: emitc.call "mhlo::reshape"(%arg0) {template_args = [tensor<2x3x2xf32>]} : (tensor<12xf32>) -> tensor<2x3x2xf32>
+  // CHECK: emitc.call "emitc::mhlo::reshape"(%arg0) {template_args = [tensor<2x3x2xf32>]} : (tensor<12xf32>) -> tensor<2x3x2xf32>
   %0 = "mhlo.reshape"(%arg0) : (tensor<12xf32>) -> tensor<2x3x2xf32>
   return %0 : tensor<2x3x2xf32>
 }
 
 func @mhlo_select(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xi1>) -> tensor<2xf32> {
-  // CHECK: emitc.call "mhlo::select"(%arg2, %arg0, %arg1) : (tensor<2xi1>, tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+  // CHECK: emitc.call "emitc::mhlo::select"(%arg2, %arg0, %arg1) : (tensor<2xi1>, tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   %1 = "mhlo.select"(%arg2, %arg0, %arg1) : (tensor<2xi1>, tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   return %1 : tensor<2xf32>
 }
@@ -402,14 +402,14 @@ func @mhlo_rng_uniform() -> () {
   %cst_0 = "std.constant"() {value = dense<100> : tensor<i32>} : () -> tensor<i32>
   %cst_1 = "std.constant"() {value = dense<2> : tensor<1xi64>} : () -> tensor<1xi64>
 
-  // CHECK: emitc.call "mhlo::rng_uniform"(%cst, %cst_0, %cst_1) {template_args = [tensor<2xi32>]} : (tensor<i32>, tensor<i32>, tensor<1xi64>) -> tensor<2xi32>
+  // CHECK: emitc.call "emitc::mhlo::rng_uniform"(%cst, %cst_0, %cst_1) {template_args = [tensor<2xi32>]} : (tensor<i32>, tensor<i32>, tensor<1xi64>) -> tensor<2xi32>
   %0 = "mhlo.rng_uniform"(%cst, %cst_0, %cst_1) : (tensor<i32>, tensor<i32>, tensor<1xi64>) -> tensor<2xi32>
   
   %cst_2 = "std.constant"() {value = dense<-100.0> : tensor<f32>} : () -> tensor<f32>
   %cst_3 = "std.constant"() {value = dense<100.0> : tensor<f32>} : () -> tensor<f32>
   %cst_4 = "std.constant"() {value = dense<17> : tensor<1xi64>} : () -> tensor<1xi64>
 
-  // CHECK: emitc.call "mhlo::rng_uniform"(%cst_2, %cst_3, %cst_4) {template_args = [tensor<17xf32>]} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
+  // CHECK: emitc.call "emitc::mhlo::rng_uniform"(%cst_2, %cst_3, %cst_4) {template_args = [tensor<17xf32>]} : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
   %1 = "mhlo.rng_uniform"(%cst_2, %cst_3, %cst_4) : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
   return
 }
@@ -417,10 +417,10 @@ func @mhlo_rng_uniform() -> () {
 func @mhlo_rng_bit_generator() -> () {
   %cst = "std.constant"() {value = dense<2> : tensor<3xui64>} : () -> tensor<3xui64>
 
-  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x2xui32>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
+  // CHECK: emitc.call "emitc::mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x2xui32>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
   %0 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
   
-  // CHECK: emitc.call "mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x7x3xf64>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
+  // CHECK: emitc.call "emitc::mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x7x3xf64>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
   %1 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
   return
 }

--- a/test/Conversion/std-to-emitc.mlir
+++ b/test/Conversion/std-to-emitc.mlir
@@ -8,14 +8,14 @@ func @std_index_cast(%arg0: tensor<index>, %arg1: tensor<2xi32>, %arg2: tensor<2
   return %1 : tensor<2xindex>
 }
 // CHECK-LABEL: func @std_index_cast
-//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg0) {template_args = [tensor<i32>]} : (tensor<index>) -> tensor<i32>
-//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg1) {template_args = [tensor<2xindex>]} : (tensor<2xi32>) -> tensor<2xindex>
-//  CHECK-NEXT: emitc.call "standard::index_cast"(%arg2) {template_args = [tensor<2x2xindex>]} : (tensor<2x2xi32>) -> tensor<2x2xindex>
+//  CHECK-NEXT: emitc.call "emitc::standard::index_cast"(%arg0) {template_args = [tensor<i32>]} : (tensor<index>) -> tensor<i32>
+//  CHECK-NEXT: emitc.call "emitc::standard::index_cast"(%arg1) {template_args = [tensor<2xindex>]} : (tensor<2xi32>) -> tensor<2xindex>
+//  CHECK-NEXT: emitc.call "emitc::standard::index_cast"(%arg2) {template_args = [tensor<2x2xindex>]} : (tensor<2x2xi32>) -> tensor<2x2xindex>
 
 // CPP-LABEL: Tensor<size_t, 2> std_index_cast(Tensor<size_t> v1, Tensor<int32_t, 2> v2, Tensor<int32_t, 2, 2> v3)
-//  CPP-NEXT: standard::index_cast<Tensor<int32_t>>(v1)
-//  CPP-NEXT: standard::index_cast<Tensor<size_t, 2>>(v2)
-//  CPP-NEXT: standard::index_cast<Tensor<size_t, 2, 2>>(v3)
+//  CPP-NEXT: emitc::standard::index_cast<Tensor<int32_t>>(v1)
+//  CPP-NEXT: emitc::standard::index_cast<Tensor<size_t, 2>>(v2)
+//  CPP-NEXT: emitc::standard::index_cast<Tensor<size_t, 2, 2>>(v3)
 //  CPP-NEXT: return v5;
 
 func @splat_op(%s : f32) -> tensor<8xf32> {
@@ -23,8 +23,8 @@ func @splat_op(%s : f32) -> tensor<8xf32> {
   return %t : tensor<8xf32>
 }
 // CHECK-LABEL: func @splat_op
-//  CHECK-NEXT: emitc.call "standard::splat"(%arg0) {template_args = [tensor<8xf32>]} : (f32) -> tensor<8xf32>
+//  CHECK-NEXT: emitc.call "emitc::standard::splat"(%arg0) {template_args = [tensor<8xf32>]} : (f32) -> tensor<8xf32>
 
 // CPP-LABEL: Tensor<float, 8> splat_op(float v1)
-//  CPP-NEXT: standard::splat<Tensor<float, 8>>(v1)
+//  CPP-NEXT: emitc::standard::splat<Tensor<float, 8>>(v1)
 //  CPP-NEXT: return v2;

--- a/test/Conversion/tensor-to-emitc.mlir
+++ b/test/Conversion/tensor-to-emitc.mlir
@@ -12,13 +12,13 @@ func @std_extract_element(%arg0: tensor<i32>, %arg1: tensor<2xi32>) -> () {
 // CHECK-LABEL: func @std_extract_element
 //  CHECK-NEXT: constant 0 : index
 //  CHECK-NEXT: constant 1 : index
-//  CHECK-NEXT: emitc.call "tensor::extract"(%arg0) : (tensor<i32>) -> i32
-//  CHECK-NEXT: emitc.call "tensor::extract"(%arg1, %c0) : (tensor<2xi32>, index) -> i32
-//  CHECK-NEXT: emitc.call "tensor::extract"(%arg1, %c1) : (tensor<2xi32>, index) -> i32
+//  CHECK-NEXT: emitc.call "emitc::tensor::extract"(%arg0) : (tensor<i32>) -> i32
+//  CHECK-NEXT: emitc.call "emitc::tensor::extract"(%arg1, %c0) : (tensor<2xi32>, index) -> i32
+//  CHECK-NEXT: emitc.call "emitc::tensor::extract"(%arg1, %c1) : (tensor<2xi32>, index) -> i32
 
 // CPP-LABEL: void std_extract_element(Tensor<int32_t> v1, Tensor<int32_t, 2> v2)
 //  CPP-NEXT: size_t v3{0};
 //  CPP-NEXT: size_t v4{1};
-//  CPP-NEXT: tensor::extract(v1)
-//  CPP-NEXT: tensor::extract(v2, v3)
-//  CPP-NEXT: tensor::extract(v2, v4)
+//  CPP-NEXT: emitc::tensor::extract(v1)
+//  CPP-NEXT: emitc::tensor::extract(v2, v3)
+//  CPP-NEXT: emitc::tensor::extract(v2, v4)

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -12,75 +12,75 @@ func @test_const(%arg0 : index) -> tensor<4xi32> {
 // Unary elementwise ops
 
 func @test_abs(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::abs"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::abs"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.abs"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 // CHECK-LABEL: cast
 func @test_cast(%arg0: tensor<13x21x3xi32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::cast"(%arg0) {template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::cast"(%arg0) {template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xf32>
   %0 = "tosa.cast"(%arg0) : (tensor<13x21x3xi32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_ceil(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::ceil"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::ceil"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.ceil"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_clamp0(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::clamp"(%arg0) {args = [0 : index, 0.000000e+00 : f32, 1.000000e+00 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::clamp"(%arg0) {args = [0 : index, 0.000000e+00 : f32, 1.000000e+00 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.clamp"(%arg0) {min_fp = 0.0 : f32, max_fp = 1.0 : f32, min_int = -2 : i64, max_int = 2 : i64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_clamp1(%arg0: tensor<13x21x3xi32>) -> tensor<13x21x3xi32> {
-  // CHECK: %0 = emitc.call "tosa::clamp"(%arg0) {args = [0 : index, -2 : i32, 2 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  // CHECK: %0 = emitc.call "emitc::tosa::clamp"(%arg0) {args = [0 : index, -2 : i32, 2 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   %0 = "tosa.clamp"(%arg0) {min_fp = 0.0 : f32, max_fp = 1.0 : f32, min_int = -2 : i64, max_int = 2 : i64} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   return %0 : tensor<13x21x3xi32>
 }
 
 func @test_exp(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.exp"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_floor(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::floor"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::floor"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.floor"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_log(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::log"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::log"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.log"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_negate(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::negate"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::negate"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.negate"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_reciprocal(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reciprocal"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reciprocal"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.reciprocal"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_rsqrt(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: %0 = emitc.call "emitc::sqrt"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reciprocal"(%0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::reciprocal"(%0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.rsqrt"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_tanh(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::tanh"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::tanh"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.tanh"(%arg0) : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
@@ -89,14 +89,14 @@ func @test_tanh(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 
 func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg0) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
-  // CHECK: emitc.call "tosa::add"(%0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::add"(%0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.add"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 // MulOp: no broadcast
 func @test_mul10(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: emitc.call "tosa::mul"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 0 : i32 } : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
@@ -104,7 +104,7 @@ func @test_mul10(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x3xf32>) -> tens
 // MulOp: First operand needs to be broadcasted
 func @test_mul1(%arg0: tensor<13x1x3xi32>, %arg1: tensor<13x21x3xi32>) -> tensor<13x21x3xi32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg0) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xi32>]} : (tensor<13x1x3xi32>) -> tensor<13x21x3xi32>
-  // CHECK: emitc.call "tosa::mul"(%0, %arg1) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%0, %arg1) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 1 : i32 } : (tensor<13x1x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   return %0 : tensor<13x21x3xi32>
 }
@@ -112,7 +112,7 @@ func @test_mul1(%arg0: tensor<13x1x3xi32>, %arg1: tensor<13x21x3xi32>) -> tensor
 // MulOp: Second operand needs to be broadcasted
 func @test_mul2(%arg0: tensor<13x21x3xi32>, %arg1: tensor<13x1x3xi32>) -> tensor<13x21x3xi32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xi32>]} : (tensor<13x1x3xi32>) -> tensor<13x21x3xi32>
-  // CHECK: emitc.call "tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 1 : i32 } : (tensor<13x21x3xi32>, tensor<13x1x3xi32>) -> tensor<13x21x3xi32>
   return %0 : tensor<13x21x3xi32>
 }
@@ -120,7 +120,7 @@ func @test_mul2(%arg0: tensor<13x21x3xi32>, %arg1: tensor<13x1x3xi32>) -> tensor
 // MulOp: Second operand needs to be broadcasted + expanded to two dimensions
 func @test_mul3(%arg0: tensor<21x3xi32>, %arg1: tensor<3xi32>) -> tensor<21x3xi32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<1> : tensor<1xi64>], template_args = [tensor<21x3xi32>]} : (tensor<3xi32>) -> tensor<21x3xi32>
-  // CHECK: emitc.call "tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 3 : i32]} : (tensor<21x3xi32>, tensor<21x3xi32>) -> tensor<21x3xi32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 3 : i32]} : (tensor<21x3xi32>, tensor<21x3xi32>) -> tensor<21x3xi32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 3 : i32 } : (tensor<21x3xi32>, tensor<3xi32>) -> tensor<21x3xi32>
   return %0 : tensor<21x3xi32>
 }
@@ -128,7 +128,7 @@ func @test_mul3(%arg0: tensor<21x3xi32>, %arg1: tensor<3xi32>) -> tensor<21x3xi3
 // MulOp: Second operand needs to be broadcasted + expanded to three dimensions
 func @test_mul4(%arg0: tensor<13x21x3xi32>, %arg1: tensor<3xi32>) -> tensor<13x21x3xi32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<2> : tensor<1xi64>], template_args = [tensor<13x21x3xi32>]} : (tensor<3xi32>) -> tensor<13x21x3xi32>
-  // CHECK: emitc.call "tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 1 : i32]} : (tensor<13x21x3xi32>, tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 1 : i32 } : (tensor<13x21x3xi32>, tensor<3xi32>) -> tensor<13x21x3xi32>
   return %0 : tensor<13x21x3xi32>
 }
@@ -136,35 +136,35 @@ func @test_mul4(%arg0: tensor<13x21x3xi32>, %arg1: tensor<3xi32>) -> tensor<13x2
 // MulOp: Second two dimensional operand needs to be broadcasted + expanded to four dimensions
 func @test_mul5(%arg0: tensor<2x13x21x3xi32>, %arg1: tensor<21x3xi32>) -> tensor<2x13x21x3xi32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[2, 3]> : tensor<2xi64>], template_args = [tensor<2x13x21x3xi32>]} : (tensor<21x3xi32>) -> tensor<2x13x21x3xi32>
-  // CHECK: emitc.call "tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 5 : i32]} : (tensor<2x13x21x3xi32>, tensor<2x13x21x3xi32>) -> tensor<2x13x21x3xi32>
+  // CHECK: emitc.call "emitc::tosa::mul"(%arg0, %0) {args = [0 : index, 1 : index, 5 : i32]} : (tensor<2x13x21x3xi32>, tensor<2x13x21x3xi32>) -> tensor<2x13x21x3xi32>
   %0 = "tosa.mul"(%arg0, %arg1)  { shift = 5 : i32 } : (tensor<2x13x21x3xi32>, tensor<21x3xi32>) -> tensor<2x13x21x3xi32>
   return %0 : tensor<2x13x21x3xi32>
 }
 
 func @test_maximum(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x3xf32> {
   // CHECK: %0 = emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::maximum"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::maximum"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.maximum"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_minimum(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: %0 = emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xf32>]} : (tensor<1x21x3xf32>) -> tensor<13x21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::minimum"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::minimum"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.minimum"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<1x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
   // CHECK: emitc.call "emitc::broadcast_in_dim"(%arg0) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
-  // CHECK: emitc.call "tosa::sub"(%0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: emitc.call "emitc::tosa::sub"(%0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.sub"(%arg0, %arg1) : (tensor<13x21x1xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_pow(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x1xf32>) -> tensor<13x21x3xf32> {
   // CHECK: %0 = emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<13x21x3xf32>]} : (tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::pow"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::pow"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.pow"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<13x21x1xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
@@ -172,90 +172,90 @@ func @test_pow(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x21x1xf32>) -> tensor
 // Other ops
 
 func @test_conv2d(%arg0: tensor<1x4x4x4xf32>, %arg1: tensor<8x1x1x4xf32>, %arg2: tensor<8xf32>) -> tensor<1x4x4x8xf32> {
-    // CHECK: %0 = emitc.call "tosa::conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x4x4x8xf32>]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>) -> tensor<1x4x4x8xf32>
+    // CHECK: %0 = emitc.call "emitc::tosa::conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x4x4x8xf32>]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>) -> tensor<1x4x4x8xf32>
     // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [0 : index, dense<3> : tensor<1xi64>], template_args = [tensor<1x4x4x8xf32>]} : (tensor<8xf32>) -> tensor<1x4x4x8xf32>
-    // CHECK: %2 = emitc.call "tosa::add"(%0, %1) : (tensor<1x4x4x8xf32>, tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
+    // CHECK: %2 = emitc.call "emitc::tosa::add"(%0, %1) : (tensor<1x4x4x8xf32>, tensor<1x4x4x8xf32>) -> tensor<1x4x4x8xf32>
     %0 = "tosa.conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x4x4x4xf32>, tensor<8x1x1x4xf32>, tensor<8xf32>) -> tensor<1x4x4x8xf32>
     return %0 : tensor<1x4x4x8xf32>
 }
 
 func @test_depthwise_conv2d(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<2x2x2x2xf32>, %arg2: tensor<4xf32>) -> tensor<1x3x4x4xf32> {
-    // CHECK: %0 = emitc.call "tosa::depthwise_conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>) -> tensor<1x3x4x4xf32>
+    // CHECK: %0 = emitc.call "emitc::tosa::depthwise_conv2d"(%arg0, %arg1) {args = [0 : index, 1 : index, dense<0> : tensor<4xi64>, dense<1> : tensor<2xi64>, dense<1> : tensor<2xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>) -> tensor<1x3x4x4xf32>
     // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [0 : index, dense<3> : tensor<1xi64>], template_args = [tensor<1x3x4x4xf32>]} : (tensor<4xf32>) -> tensor<1x3x4x4xf32>
-    // CHECK: %2 = emitc.call "tosa::add"(%0, %1) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
+    // CHECK: %2 = emitc.call "emitc::tosa::add"(%0, %1) : (tensor<1x3x4x4xf32>, tensor<1x3x4x4xf32>) -> tensor<1x3x4x4xf32>
     %0 = "tosa.depthwise_conv2d"(%arg0, %arg1, %arg2) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<1x4x5x2xf32>, tensor<2x2x2x2xf32>, tensor<4xf32>) -> tensor<1x3x4x4xf32>
     return %0 : tensor<1x3x4x4xf32>
 }
 
 func @test_fully_connected(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
-  // CHECK: emitc.call "tosa::fully_connected"(%arg0, %arg1, %arg2) {template_args = [tensor<14x28xf32>]} : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>
+  // CHECK: emitc.call "emitc::tosa::fully_connected"(%arg0, %arg1, %arg2) {template_args = [tensor<14x28xf32>]} : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   %0 = "tosa.fully_connected"(%arg0, %arg1, %arg2) : (tensor<14x19xf32>, tensor<19x28xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   return %0 : tensor<14x28xf32>
 }
 
 func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<14x28xf32> {
-  // CHECK: emitc.call "tosa::matmul"(%arg0, %arg1) : (tensor<14x19xf32>, tensor<19x28xf32>) -> tensor<14x28xf32>
+  // CHECK: emitc.call "emitc::tosa::matmul"(%arg0, %arg1) : (tensor<14x19xf32>, tensor<19x28xf32>) -> tensor<14x28xf32>
   %0 = "tosa.matmul"(%arg0, %arg1) : (tensor<14x19xf32>, tensor<19x28xf32>) -> tensor<14x28xf32>
   return %0 : tensor<14x28xf32>
 }
 
 // Reduce ops
 func @test_reduce_all(%arg0: tensor<13x21x3xi1>) -> tensor<1x21x3xi1> {
-  // CHECK: %0 = emitc.call "tosa::reduce_all"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xi1>, tensor<13x21x3xi1>]} : (tensor<13x21x3xi1>) -> tensor<21x3xi1>
-  // CHECK: %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<1x21x3xi1>]} : (tensor<21x3xi1>) -> tensor<1x21x3xi1>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_all"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xi1>, tensor<13x21x3xi1>]} : (tensor<13x21x3xi1>) -> tensor<21x3xi1>
+  // CHECK: %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<1x21x3xi1>]} : (tensor<21x3xi1>) -> tensor<1x21x3xi1>
   %0 = "tosa.reduce_all"(%arg0) {axis = 0 : i64} : (tensor<13x21x3xi1>) -> tensor<1x21x3xi1>
   return %0 : tensor<1x21x3xi1>
 }
 
 func @test_reduce_any(%arg0: tensor<13x21x3xi1>) -> tensor<13x1x3xi1> {
-  // CHECK: %0 = emitc.call "tosa::reduce_any"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xi1>, tensor<13x21x3xi1>]} : (tensor<13x21x3xi1>) -> tensor<13x3xi1>
-  // %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<13x1x3xi1>]} : (tensor<13x3xi1>) -> tensor<13x1x3xi1>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_any"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xi1>, tensor<13x21x3xi1>]} : (tensor<13x21x3xi1>) -> tensor<13x3xi1>
+  // %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<13x1x3xi1>]} : (tensor<13x3xi1>) -> tensor<13x1x3xi1>
   %0 = "tosa.reduce_any"(%arg0) {axis = 1 : i64} : (tensor<13x21x3xi1>) -> tensor<13x1x3xi1>
   return %0 : tensor<13x1x3xi1>
 }
 
 func @test_reduce_max(%arg0: tensor<13x21x3xf32>) -> tensor<1x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reduce_max"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<1x21x3xf32>]} : (tensor<21x3xf32>) -> tensor<1x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_max"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<1x21x3xf32>]} : (tensor<21x3xf32>) -> tensor<1x21x3xf32>
   %0 = "tosa.reduce_max"(%arg0) {axis = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<1x21x3xf32>
   return %0 : tensor<1x21x3xf32>
 }
 
 func @test_reduce_min(%arg0: tensor<13x21x3xf32>) -> tensor<13x1x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reduce_min"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<13x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<13x1x3xf32>]} : (tensor<13x3xf32>) -> tensor<13x1x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_min"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<13x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<13x1x3xf32>]} : (tensor<13x3xf32>) -> tensor<13x1x3xf32>
   %0 = "tosa.reduce_min"(%arg0) {axis = 1 : i64} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
   return %0 : tensor<13x1x3xf32>
 }
 
 func @test_reduce_prod(%arg0: tensor<13x21x3xf32>) -> tensor<1x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reduce_prod"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<21x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<1x21x3xf32>]} : (tensor<21x3xf32>) -> tensor<1x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_prod"(%arg0) {args = [0 : index, 0], template_args = [tensor<21x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<21x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<1x21x3xf32>]} : (tensor<21x3xf32>) -> tensor<1x21x3xf32>
   %0 = "tosa.reduce_prod"(%arg0) {axis = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<1x21x3xf32>
   return %0 : tensor<1x21x3xf32>
 }
 
 func @test_reduce_sum(%arg0: tensor<13x21x3xf32>) -> tensor<13x1x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reduce_sum"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<13x3xf32>
-  // CHECK: %1 = emitc.call "tosa::reshape"(%0) {template_args = [tensor<13x1x3xf32>]} : (tensor<13x3xf32>) -> tensor<13x1x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reduce_sum"(%arg0) {args = [0 : index, 1], template_args = [tensor<13x3xf32>, tensor<13x21x3xf32>]} : (tensor<13x21x3xf32>) -> tensor<13x3xf32>
+  // CHECK: %1 = emitc.call "emitc::tosa::reshape"(%0) {template_args = [tensor<13x1x3xf32>]} : (tensor<13x3xf32>) -> tensor<13x1x3xf32>
   %0 = "tosa.reduce_sum"(%arg0) {axis = 1 : i64} : (tensor<13x21x3xf32>) -> tensor<13x1x3xf32>
   return %0 : tensor<13x1x3xf32>
 }
 
 func @test_slice(%arg0: tensor<13x21x3xf32>) -> tensor<4x11x1xf32> {
-  // CHECK: %0 = emitc.call "tosa::slice"(%arg0) {args = [0 : index, dense<[6, 8, 0]> : tensor<3xi64>, dense<[4, 11, 1]> : tensor<3xi64>], template_args = [tensor<4x11x1xf32>]} : (tensor<13x21x3xf32>) -> tensor<4x11x1xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::slice"(%arg0) {args = [0 : index, dense<[6, 8, 0]> : tensor<3xi64>, dense<[4, 11, 1]> : tensor<3xi64>], template_args = [tensor<4x11x1xf32>]} : (tensor<13x21x3xf32>) -> tensor<4x11x1xf32>
   %0 = "tosa.slice"(%arg0) {start = [6, 8, 0], size = [4, 11, 1]} : (tensor<13x21x3xf32>) -> tensor<4x11x1xf32>
   return %0 : tensor<4x11x1xf32>
 }
 
 func @test_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<2x2xi32>) -> tensor<3x6xf32> {
-  // CHECK: %0 = emitc.call "tosa::pad"(%arg0, %arg1) {template_args = [tensor<3x6xf32>]} : (tensor<2x3xf32>, tensor<2x2xi32>) -> tensor<3x6xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::pad"(%arg0, %arg1) {template_args = [tensor<3x6xf32>]} : (tensor<2x3xf32>, tensor<2x2xi32>) -> tensor<3x6xf32>
   %0 = "tosa.pad"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<2x2xi32>) -> tensor<3x6xf32>
   return %0 : tensor<3x6xf32>
 }
 
 func @test_reshape(%arg0: tensor<13x21x3xf32>) -> tensor<1x819xf32> {
-  // CHECK: %0 = emitc.call "tosa::reshape"(%arg0) {template_args = [tensor<1x819xf32>]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reshape"(%arg0) {template_args = [tensor<1x819xf32>]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>
   %0 = "tosa.reshape"(%arg0) {new_shape = [1, 819]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>
   return %0 : tensor<1x819xf32>
 }
@@ -263,31 +263,31 @@ func @test_reshape(%arg0: tensor<13x21x3xf32>) -> tensor<1x819xf32> {
 func @test_transpose(%arg0: tensor<13x21x3xf32>) -> tensor<3x13x21xf32> {
   // CHECK: %0 = "emitc.const"() {value = dense<[2, 0, 1]> : tensor<3xi32>} : () -> tensor<3xi32>
   %0 = "tosa.const"() {value = dense<[2, 0, 1]> : tensor<3xi32>} : () -> tensor<3xi32>
-  // CHECK-NEXT: %1 = emitc.call "tosa::transpose"(%arg0, %0) {template_args = [tensor<3x13x21xf32>]} : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>
+  // CHECK-NEXT: %1 = emitc.call "emitc::tosa::transpose"(%arg0, %0) {template_args = [tensor<3x13x21xf32>]} : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>
   %1 = "tosa.transpose"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>
   return %1 : tensor<3x13x21xf32>
 }
 
 func @test_relu0(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 3.40282347E+38 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 3.40282347E+38 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   %0 = "tosa.reluN"(%arg0) {max_fp = 3.40282347E+38 : f32, max_int = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
   return %0 : tensor<13x21x3xf32>
 }
 
 func @test_relu1(%arg0: tensor<13x21x3xi64>) -> tensor<13x21x3xi64> {
-  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 255]} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
+  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 255]} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
   %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
   return %0 : tensor<13x21x3xi64>
 }
 
 func @test_relu2(%arg0: tensor<13x21x3xi32>) -> tensor<13x21x3xi32> {
-  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 255 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
+  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 255 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
   return %0 : tensor<13x21x3xi32>
 }
 
 func @test_relu3(%arg0: tensor<13x21x3xf16>) -> tensor<13x21x3xf16> {
-  // CHECK: %0 = emitc.call "tosa::reluN"(%arg0) {args = [0 : index, 1.500000e+00 : f16]} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
+  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 1.500000e+00 : f16]} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
   %0 = "tosa.reluN"(%arg0) {max_fp = 1.5 : f32, max_int = 0 : i64} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
   return %0 : tensor<13x21x3xf16>
 }

--- a/test/MobileNetV2_tosa_test.cpp
+++ b/test/MobileNetV2_tosa_test.cpp
@@ -17,9 +17,9 @@ bool check_tensor(T result, U expected, float eps, bool print_error) {
 int main() {
 
   Tensor<float, 1, 224, 224, 3> input0 =
-      standard::splat<Tensor<float, 1, 224, 224, 3>>(0.5f);
+      emitc::standard::splat<Tensor<float, 1, 224, 224, 3>>(0.5f);
   Tensor<float, 1, 1000> output0 =
-      standard::splat<Tensor<float, 1, 1000>>(0.0010000000474974513f);
+      emitc::standard::splat<Tensor<float, 1, 1000>>(0.0010000000474974513f);
   Tensor<float, 1, 1000> result0;
   bool error = false;
   float EPS = 1e-4;

--- a/unittests/emitc_mhlo.cpp
+++ b/unittests/emitc_mhlo.cpp
@@ -17,6 +17,7 @@
 
 namespace {
 
+using namespace emitc;
 using ::testing::DoubleEq;
 using ::testing::Eq;
 using ::testing::FloatEq;

--- a/unittests/emitc_std.cpp
+++ b/unittests/emitc_std.cpp
@@ -17,6 +17,7 @@
 
 namespace {
 
+using namespace emitc;
 using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::Pointwise;

--- a/unittests/emitc_tensor.cpp
+++ b/unittests/emitc_tensor.cpp
@@ -17,6 +17,7 @@
 
 namespace {
 
+using namespace emitc;
 using ::testing::Eq;
 
 TEST(tensor, extract) {

--- a/unittests/emitc_tosa.cpp
+++ b/unittests/emitc_tosa.cpp
@@ -17,6 +17,7 @@
 
 namespace {
 
+using namespace emitc;
 using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::FloatNear;


### PR DESCRIPTION
All our header only functions are actually reference implementations provided within the scope of `emitc`. Therefore, this moves the `mhlo`, `standard`, `tensor` and `tosa` namespaces into the top-level `emitc` namespace. The `emitc` namespace used in MIR-related parts will soon be moved to `mlir::emitc`.