### PR TITLE
Add EmitC include operation

### DIFF
--- a/docs/EmitC.md
+++ b/docs/EmitC.md
@@ -138,7 +138,7 @@ include operation
 Syntax:
 
 ```
-operation ::= `emitc.include` $include attr-dict
+operation ::= `emitc.include` $include attr-dict (`is_standard_include` $is_standard_include^)?
 ```
 
 The `include` operation allows to define a source file inclusion via the
@@ -149,6 +149,7 @@ The `include` operation allows to define a source file inclusion via the
 | Attribute | MLIR Type | Description |
 | :-------: | :-------: | ----------- |
 `include` | ::mlir::StringAttr | string attribute
+`is_standard_include` | ::mlir::UnitAttr | unit attribute
 
 ## Type definition
 

--- a/docs/EmitC.md
+++ b/docs/EmitC.md
@@ -130,6 +130,26 @@ is intended to support opaque attributes and EmitC's opaque type.
 | :----: | ----------- |
 &laquo;unnamed&raquo; | any type
 
+### `emitc.include` (::mlir::emitc::IncludeOp)
+
+include operation
+
+
+Syntax:
+
+```
+operation ::= `emitc.include` $include attr-dict
+```
+
+The `include` operation allows to define a source file inclusion via the
+`#include` directive.
+
+#### Attributes:
+
+| Attribute | MLIR Type | Description |
+| :-------: | :-------: | ----------- |
+`include` | ::mlir::StringAttr | string attribute
+
 ## Type definition
 
 ### OpaqueType

--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -183,9 +183,11 @@ def EmitC_IncludeOp : EmitC_Op<"include", [NoSideEffect, HasParent<"ModuleOp">]>
     The `include` operation allows to define a source file inclusion via the
     `#include` directive.
   }];
-  let arguments = (ins Arg<StrAttr, "source file to include">:$include);
+  let arguments = (ins
+    Arg<StrAttr, "source file to include">:$include,
+    UnitAttr:$is_standard_include);
   let assemblyFormat = [{
-    $include attr-dict
+    $include attr-dict (`is_standard_include` $is_standard_include^)?
   }];
 }
 

--- a/include/emitc/Dialect/EmitC/EmitC.td
+++ b/include/emitc/Dialect/EmitC/EmitC.td
@@ -177,4 +177,16 @@ def EmitC_ConstOp : EmitC_Op<"const", [ConstantLike, NoSideEffect]> {
   let hasFolder = 1;
 }
 
+def EmitC_IncludeOp : EmitC_Op<"include", [NoSideEffect, HasParent<"ModuleOp">]> {
+  let summary = "include operation";
+  let description = [{
+    The `include` operation allows to define a source file inclusion via the
+    `#include` directive.
+  }];
+  let arguments = (ins Arg<StrAttr, "source file to include">:$include);
+  let assemblyFormat = [{
+    $include attr-dict
+  }];
+}
+
 #endif // EMITC_OPS

--- a/include/emitc/Dialect/EmitC/EmitCDialect.h
+++ b/include/emitc/Dialect/EmitC/EmitCDialect.h
@@ -13,6 +13,7 @@
 #ifndef EMITC_DIALECT_EMITC_EMITCDIALECT_H
 #define EMITC_DIALECT_EMITC_EMITCDIALECT_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -423,6 +423,11 @@ static LogicalResult printModule(CppEmitter &emitter, ModuleOp moduleOp) {
     os << "#include \"emitc_tosa.h\"\n\n";
   }
 
+  for (emitc::IncludeOp includeOp : moduleOp.getOps<emitc::IncludeOp>()) {
+          os << "#include " << includeOp.include() << "\n";
+  }
+  os << "\n";
+
   os << "// Forward declare functions.\n";
   for (FuncOp funcOp : moduleOp.getOps<FuncOp>()) {
     if (failed(emitter.emitTypes(*funcOp.getOperation(),
@@ -784,6 +789,9 @@ static LogicalResult printOperation(CppEmitter &emitter, Operation &op) {
     return printCallOp(emitter, callOp);
   if (auto constOp = dyn_cast<emitc::ConstOp>(op))
     return printConstantOp(emitter, constOp);
+  if (auto includeOp = dyn_cast<emitc::IncludeOp>(op))
+    // IncludeOp were already printed via printModule.
+    return success();
 
   // SCF ops.
   if (auto forOp = dyn_cast<scf::ForOp>(op))

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -424,7 +424,12 @@ static LogicalResult printModule(CppEmitter &emitter, ModuleOp moduleOp) {
   }
 
   for (emitc::IncludeOp includeOp : moduleOp.getOps<emitc::IncludeOp>()) {
-          os << "#include " << includeOp.include() << "\n";
+    os << "#include ";
+    if (includeOp.is_standard_include()) {
+      os << "<" << includeOp.include() << ">\n";
+    } else {
+      os << "\"" << includeOp.include() << "\"\n";
+    }
   }
   os << "\n";
 

--- a/test/Dialect/EmitC/ops.mlir
+++ b/test/Dialect/EmitC/ops.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-opt -allow-unregistered-dialect -verify-diagnostics %s | FileCheck %s
 
-"emitc.include" (){include = "<test.h>"} : () -> ()
-emitc.include "<test.h>"
+"emitc.include" (){include = "test.h", is_standard_include} : () -> ()
+emitc.include "test.h" is_standard_include
 
 // CHECK-LABEL: func @f(%{{.*}}: i32, %{{.*}}: !custom.int32_t) -> i1 {
 func @f(%arg0: i32, %f: !custom<"int32_t">) -> i1 {

--- a/test/Dialect/EmitC/ops.mlir
+++ b/test/Dialect/EmitC/ops.mlir
@@ -1,5 +1,8 @@
 // RUN: emitc-opt -allow-unregistered-dialect -verify-diagnostics %s | FileCheck %s
 
+"emitc.include" (){include = "<test.h>"} : () -> ()
+emitc.include "<test.h>"
+
 // CHECK-LABEL: func @f(%{{.*}}: i32, %{{.*}}: !custom.int32_t) -> i1 {
 func @f(%arg0: i32, %f: !custom<"int32_t">) -> i1 {
   %1 = "emitc.call"() {callee = "blah"} : () -> i64

--- a/test/Target/common-cpp.mlir
+++ b/test/Target/common-cpp.mlir
@@ -1,9 +1,9 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s
 
 // CHECK: #include "myheader.h"
-emitc.include "\"myheader.h\""
+emitc.include "myheader.h"
 // CHECK: #include <myheader.h>
-emitc.include "<myheader.h>"
+emitc.include "myheader.h" is_standard_include
 
 // CHECK: void test_foo_print() {
 func @test_foo_print() {

--- a/test/Target/common-cpp.mlir
+++ b/test/Target/common-cpp.mlir
@@ -1,5 +1,10 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s
 
+// CHECK: #include "myheader.h"
+emitc.include "\"myheader.h\""
+// CHECK: #include <myheader.h>
+emitc.include "<myheader.h>"
+
 // CHECK: void test_foo_print() {
 func @test_foo_print() {
   // CHECK: [[V1:[^ ]*]] = foo::constant({0, 1});


### PR DESCRIPTION
This adds an include operation that allows to  define a source file
inclusion via `#include` directive. With the unit attribute
`is_standard_include` defined, the inclusion is emitted as
`#include <filename>`. Otherwise the inclusion is emitted as
`#include "filename"`.