### PR TITLE
Rename CMake target MLIREmitCPassIncGen

### DIFF
--- a/include/emitc/Dialect/EmitC/Conversion/CMakeLists.txt
+++ b/include/emitc/Dialect/EmitC/Conversion/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(LLVM_TARGET_DEFINITIONS Passes.td)
-mlir_tablegen(Passes.h.inc -gen-pass-decls -name EmitC)
-add_public_tablegen_target(MLIREmitCPassIncGen)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name EmitCConversion)
+add_public_tablegen_target(MLIREmitCConversionPassIncGen)

--- a/lib/Dialect/EmitC/Conversion/CMakeLists.txt
+++ b/lib/Dialect/EmitC/Conversion/CMakeLists.txt
@@ -12,7 +12,7 @@ if(EMITC_ENABLE_HLO)
 
     DEPENDS
     MLIREmitCIncGen
-    MLIREmitCPassIncGen
+    MLIREmitCConversionPassIncGen
     MLIRhlo_opsIncGen
 
     LINK_COMPONENTS
@@ -29,7 +29,7 @@ if(EMITC_ENABLE_HLO)
 
     DEPENDS
     MLIREmitCIncGen
-    MLIREmitCPassIncGen
+    MLIREmitCConversionPassIncGen
     MLIRhlo_opsIncGen
 
     LINK_COMPONENTS
@@ -47,7 +47,7 @@ add_mlir_library(MLIRStdToEmitC
 
   DEPENDS
   MLIREmitCIncGen
-  MLIREmitCPassIncGen
+  MLIREmitCConversionPassIncGen
 
   LINK_COMPONENTS
   Core
@@ -63,7 +63,7 @@ add_mlir_library(MLIRTensorToEmitC
 
   DEPENDS
   MLIREmitCIncGen
-  MLIREmitCPassIncGen
+  MLIREmitCConversionPassIncGen
 
   LINK_COMPONENTS
   Core
@@ -79,7 +79,7 @@ add_mlir_library(MLIRTosaToEmitC
 
   DEPENDS
   MLIREmitCIncGen
-  MLIREmitCPassIncGen
+  MLIREmitCConversionPassIncGen
 
   LINK_COMPONENTS
   Core

--- a/tools/emitc-opt/CMakeLists.txt
+++ b/tools/emitc-opt/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${EMITC_ENABLE_HLO})
     AllMhloPasses
     )
   set(HLO_LIBS_DEPS
-    MLIREmitCPassIncGen
+    MLIREmitCConversionPassIncGen
     MLIRLmhloPassIncGen
     MLIRMhloPassIncGen
     )


### PR DESCRIPTION
Renames the CMake target MLIREmitCPassIncGen to
MLIREmitCConversionPassIncGen. The former name will be used
Transform passes.