### PR TITLE
Revise license headers

### DIFF
--- a/include/emitc/Dialect/EmitC/Conversion/Passes.td
+++ b/include/emitc/Dialect/EmitC/Conversion/Passes.td
@@ -1,6 +1,6 @@
 //===- Passes.td - EmitC pass definition file --------------*- tablegen -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/include/emitc/Target/Cpp/TranslationFlags.h
+++ b/include/emitc/Target/Cpp/TranslationFlags.h
@@ -1,6 +1,6 @@
 //===- TranslationFlags.h - EmitC translation flags -------------*- C++ -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLORegionOpsToEmitC.cpp
@@ -1,6 +1,6 @@
 //===- MHLORegionOpsToEmitC.cpp - MHLO to EmitC conversion ------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
@@ -1,6 +1,6 @@
 //===- MHLOToEmitC.cpp - MHLO to EmitC conversion ---------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
@@ -1,6 +1,6 @@
 //===- StdToEmitC.cpp - std to EmitC conversion ----------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
@@ -1,6 +1,6 @@
 //===- TensorToEmitC.cpp - Tensor to EmitC conversion -----------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/Target/Cpp/TranslationFlags.cpp
+++ b/lib/Target/Cpp/TranslationFlags.cpp
@@ -1,6 +1,6 @@
 //===- TranslationFlags.cpp - EmitC translation flags -----------*- C++ -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //


### PR DESCRIPTION
Revises the license headers of our sources files. With this we
distinguish between files that will be upstreamed and those files that
will (for now!) remain in the mlir-emitc repository.