### PR TITLE
Mechaincal Change: Rename OwningRewritePatternList

### DIFF
--- a/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
@@ -492,82 +492,80 @@ private:
 } // namespace
 
 void populateMhloToEmitcPatterns(MLIRContext *ctx,
-                                 OwningRewritePatternList &patterns) {
+                                 RewritePatternSet &patterns) {
   // Insert patterns for MHLO nullary ops.
-  patterns.insert<ConstOpConversion>(ctx);
+  patterns.add<ConstOpConversion>(ctx);
 
   // Insert patterns for MHLO unary elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::AbsOp>>(ctx, "emitc::mhlo::abs");
-  patterns.insert<CallOpConversion<mhlo::CeilOp>>(ctx, "emitc::mhlo::ceil");
-  patterns.insert<CallOpConversion<mhlo::ConvertOp>>(
-      ctx, "emitc::mhlo::convert", /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<mhlo::CosOp>>(ctx, "emitc::mhlo::cos");
-  patterns.insert<CallOpConversion<mhlo::ExpOp>>(ctx,
-                                                 "emitc::mhlo::exponential");
-  patterns.insert<CallOpConversion<mhlo::Expm1Op>>(
+  patterns.add<CallOpConversion<mhlo::AbsOp>>(ctx, "emitc::mhlo::abs");
+  patterns.add<CallOpConversion<mhlo::CeilOp>>(ctx, "emitc::mhlo::ceil");
+  patterns.add<CallOpConversion<mhlo::ConvertOp>>(ctx, "emitc::mhlo::convert",
+                                                  /*explicitResultType=*/true);
+  patterns.add<CallOpConversion<mhlo::CosOp>>(ctx, "emitc::mhlo::cos");
+  patterns.add<CallOpConversion<mhlo::ExpOp>>(ctx, "emitc::mhlo::exponential");
+  patterns.add<CallOpConversion<mhlo::Expm1Op>>(
       ctx, "emitc::mhlo::exponential_minus_one");
-  patterns.insert<CallOpConversion<mhlo::FloorOp>>(ctx, "emitc::mhlo::floor");
-  patterns.insert<CallOpConversion<mhlo::IsFiniteOp>>(ctx,
-                                                      "emitc::mhlo::is_finite");
-  patterns.insert<CallOpConversion<mhlo::LogOp>>(ctx, "emitc::mhlo::log");
-  patterns.insert<CallOpConversion<mhlo::Log1pOp>>(ctx,
-                                                   "emitc::mhlo::log_plus_one");
-  patterns.insert<CallOpConversion<mhlo::NegOp>>(ctx, "emitc::mhlo::negate");
-  patterns.insert<CallOpConversion<mhlo::RoundOp>>(ctx, "emitc::mhlo::round");
-  patterns.insert<CallOpConversion<mhlo::SinOp>>(ctx, "emitc::mhlo::sin");
-  patterns.insert<CallOpConversion<mhlo::SqrtOp>>(ctx, "emitc::mhlo::sqrt");
-  patterns.insert<CallOpConversion<mhlo::TanhOp>>(ctx, "emitc::mhlo::tanh");
+  patterns.add<CallOpConversion<mhlo::FloorOp>>(ctx, "emitc::mhlo::floor");
+  patterns.add<CallOpConversion<mhlo::IsFiniteOp>>(ctx,
+                                                   "emitc::mhlo::is_finite");
+  patterns.add<CallOpConversion<mhlo::LogOp>>(ctx, "emitc::mhlo::log");
+  patterns.add<CallOpConversion<mhlo::Log1pOp>>(ctx,
+                                                "emitc::mhlo::log_plus_one");
+  patterns.add<CallOpConversion<mhlo::NegOp>>(ctx, "emitc::mhlo::negate");
+  patterns.add<CallOpConversion<mhlo::RoundOp>>(ctx, "emitc::mhlo::round");
+  patterns.add<CallOpConversion<mhlo::SinOp>>(ctx, "emitc::mhlo::sin");
+  patterns.add<CallOpConversion<mhlo::SqrtOp>>(ctx, "emitc::mhlo::sqrt");
+  patterns.add<CallOpConversion<mhlo::TanhOp>>(ctx, "emitc::mhlo::tanh");
 
   // Insert patterns for MHLO binary elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::AddOp>>(ctx, "emitc::mhlo::add");
-  patterns.insert<CallOpConversion<mhlo::Atan2Op>>(ctx, "emitc::mhlo::atan2");
-  patterns.insert<CallOpConversion<mhlo::DivOp>>(ctx, "emitc::mhlo::div");
-  patterns.insert<CallOpConversion<mhlo::MaxOp>>(ctx, "emitc::mhlo::max");
-  patterns.insert<CallOpConversion<mhlo::MinOp>>(ctx, "emitc::mhlo::min");
-  patterns.insert<CallOpConversion<mhlo::MulOp>>(ctx, "emitc::mhlo::mul");
-  patterns.insert<CallOpConversion<mhlo::PowOp>>(ctx, "emitc::mhlo::pow");
-  patterns.insert<CallOpConversion<mhlo::ShiftLeftOp>>(
-      ctx, "emitc::mhlo::shift_left");
-  patterns.insert<CallOpConversion<mhlo::ShiftRightLogicalOp>>(
+  patterns.add<CallOpConversion<mhlo::AddOp>>(ctx, "emitc::mhlo::add");
+  patterns.add<CallOpConversion<mhlo::Atan2Op>>(ctx, "emitc::mhlo::atan2");
+  patterns.add<CallOpConversion<mhlo::DivOp>>(ctx, "emitc::mhlo::div");
+  patterns.add<CallOpConversion<mhlo::MaxOp>>(ctx, "emitc::mhlo::max");
+  patterns.add<CallOpConversion<mhlo::MinOp>>(ctx, "emitc::mhlo::min");
+  patterns.add<CallOpConversion<mhlo::MulOp>>(ctx, "emitc::mhlo::mul");
+  patterns.add<CallOpConversion<mhlo::PowOp>>(ctx, "emitc::mhlo::pow");
+  patterns.add<CallOpConversion<mhlo::ShiftLeftOp>>(ctx,
+                                                    "emitc::mhlo::shift_left");
+  patterns.add<CallOpConversion<mhlo::ShiftRightLogicalOp>>(
       ctx, "emitc::mhlo::shift_right_logical");
-  patterns.insert<CallOpConversion<mhlo::SubOp>>(ctx, "emitc::mhlo::sub");
+  patterns.add<CallOpConversion<mhlo::SubOp>>(ctx, "emitc::mhlo::sub");
 
   // Insert patterns for MHLO binary logical elementwise ops.
-  patterns.insert<CallOpConversion<mhlo::OrOp>>(ctx, "emitc::mhlo::logical_or");
-  patterns.insert<CallOpConversion<mhlo::XorOp>>(ctx,
-                                                 "emitc::mhlo::logical_xor");
+  patterns.add<CallOpConversion<mhlo::OrOp>>(ctx, "emitc::mhlo::logical_or");
+  patterns.add<CallOpConversion<mhlo::XorOp>>(ctx, "emitc::mhlo::logical_xor");
 
   // Insert patterns for MHLO tuple ops.
-  patterns.insert<CompareOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::TupleOp>>(ctx, "std::make_tuple");
-  patterns.insert<GetTupleElementOpConversion>(ctx);
+  patterns.add<CompareOpConversion>(ctx);
+  patterns.add<CallOpConversion<mhlo::TupleOp>>(ctx, "std::make_tuple");
+  patterns.add<GetTupleElementOpConversion>(ctx);
 
   // Insert patterns for MHLO slice ops.
-  patterns.insert<SliceOpConversion>(ctx);
-  patterns.insert<DynamicSliceOpConversion>(ctx);
-  patterns.insert<DynamicUpdateSliceOpConversion>(ctx);
+  patterns.add<SliceOpConversion>(ctx);
+  patterns.add<DynamicSliceOpConversion>(ctx);
+  patterns.add<DynamicUpdateSliceOpConversion>(ctx);
 
   // Insert patterns for other MHLO ops.
-  patterns.insert<BatchNormInferenceOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::BitcastConvertOp>>(
+  patterns.add<BatchNormInferenceOpConversion>(ctx);
+  patterns.add<CallOpConversion<mhlo::BitcastConvertOp>>(
       ctx, "emitc::mhlo::bitcast_convert", /*explicitResultType=*/true);
-  patterns.insert<BroadcastInDimOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::ClampOp>>(
-      ctx, "emitc::mhlo::clamp", /*explicitResultType=*/false,
-      /*explicitOperandTypes=*/true);
-  patterns.insert<ConcatenateOpConversion>(ctx);
-  patterns.insert<ConvOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::DotOp>>(ctx, "emitc::mhlo::dot",
-                                                 /*explicitResultType=*/true);
-  patterns.insert<PadOpConversion>(ctx);
-  patterns.insert<CallOpConversion<mhlo::ReshapeOp>>(
-      ctx, "emitc::mhlo::reshape", /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<mhlo::SelectOp>>(ctx, "emitc::mhlo::select");
+  patterns.add<BroadcastInDimOpConversion>(ctx);
+  patterns.add<CallOpConversion<mhlo::ClampOp>>(ctx, "emitc::mhlo::clamp",
+                                                /*explicitResultType=*/false,
+                                                /*explicitOperandTypes=*/true);
+  patterns.add<ConcatenateOpConversion>(ctx);
+  patterns.add<ConvOpConversion>(ctx);
+  patterns.add<CallOpConversion<mhlo::DotOp>>(ctx, "emitc::mhlo::dot",
+                                              /*explicitResultType=*/true);
+  patterns.add<PadOpConversion>(ctx);
+  patterns.add<CallOpConversion<mhlo::ReshapeOp>>(ctx, "emitc::mhlo::reshape",
+                                                  /*explicitResultType=*/true);
+  patterns.add<CallOpConversion<mhlo::SelectOp>>(ctx, "emitc::mhlo::select");
 
   // Insert patterns for MHLO RNG ops.
-  patterns.insert<CallOpConversion<mhlo::RngUniformOp>>(
+  patterns.add<CallOpConversion<mhlo::RngUniformOp>>(
       ctx, "emitc::mhlo::rng_uniform", /*explicitResultType=*/true);
-  patterns.insert<RngBitGeneratorOpConversion>(ctx);
+  patterns.add<RngBitGeneratorOpConversion>(ctx);
 }
 
 namespace {
@@ -650,7 +648,7 @@ struct ConvertMhloToEmitCPass
                         mhlo::RngBitGeneratorOp>();
     // clang-format on
 
-    OwningRewritePatternList patterns(&getContext());
+    RewritePatternSet patterns(&getContext());
     populateMhloToEmitcPatterns(&getContext(), patterns);
 
     if (failed(

--- a/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
@@ -75,10 +75,9 @@ private:
 };
 } // namespace
 
-void populateStdToEmitcPatterns(MLIRContext *ctx,
-                                OwningRewritePatternList &patterns) {
-  patterns.insert<IndexCastOpConversion>(ctx);
-  patterns.insert<SplatOpConversion>(ctx);
+void populateStdToEmitcPatterns(MLIRContext *ctx, RewritePatternSet &patterns) {
+  patterns.add<IndexCastOpConversion>(ctx);
+  patterns.add<SplatOpConversion>(ctx);
 }
 
 namespace {
@@ -95,7 +94,7 @@ struct ConvertStdToEmitCPass
     target.addIllegalOp<IndexCastOp>();
     target.addIllegalOp<SplatOp>();
 
-    OwningRewritePatternList patterns(&getContext());
+    RewritePatternSet patterns(&getContext());
     populateStdToEmitcPatterns(&getContext(), patterns);
 
     if (failed(

--- a/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
@@ -57,8 +57,8 @@ private:
 } // namespace
 
 void populateTensorToEmitcPatterns(MLIRContext *ctx,
-                                   OwningRewritePatternList &patterns) {
-  patterns.insert<ExtractOpConversion>(ctx);
+                                   RewritePatternSet &patterns) {
+  patterns.add<ExtractOpConversion>(ctx);
 }
 
 namespace {
@@ -73,7 +73,7 @@ struct ConvertTensorToEmitCPass
     target.addLegalDialect<emitc::EmitCDialect>();
     target.addIllegalOp<mlir::tensor::ExtractOp>();
 
-    OwningRewritePatternList patterns(&getContext());
+    RewritePatternSet patterns(&getContext());
     populateTensorToEmitcPatterns(&getContext(), patterns);
 
     if (failed(

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -684,64 +684,63 @@ private:
 } // namespace
 
 void populateTosaToEmitcPatterns(MLIRContext *ctx,
-                                 OwningRewritePatternList &patterns) {
+                                 RewritePatternSet &patterns) {
   // Insert patterns for TOSA data node ops.
-  patterns.insert<ConstOpConversion>(ctx);
+  patterns.add<ConstOpConversion>(ctx);
 
   // Insert patterns for TOSA unary elementwise ops.
-  patterns.insert<CallOpConversion<tosa::AbsOp>>(ctx, "emitc::tosa::abs");
-  patterns.insert<CallOpConversion<tosa::CastOp>>(ctx, "emitc::tosa::cast",
-                                                  /*explicitResultType=*/true);
-  patterns.insert<CallOpConversion<tosa::CeilOp>>(ctx, "emitc::tosa::ceil");
-  patterns.insert<ClampOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::ExpOp>>(ctx, "emitc::tosa::exp");
-  patterns.insert<CallOpConversion<tosa::FloorOp>>(ctx, "emitc::tosa::floor");
-  patterns.insert<CallOpConversion<tosa::LogOp>>(ctx, "emitc::tosa::log");
-  patterns.insert<NegateOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::ReciprocalOp>>(
-      ctx, "emitc::tosa::reciprocal");
-  patterns.insert<ReluNOpConversion>(ctx);
-  patterns.insert<RsqrtOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::TanhOp>>(ctx, "emitc::tosa::tanh");
+  patterns.add<CallOpConversion<tosa::AbsOp>>(ctx, "emitc::tosa::abs");
+  patterns.add<CallOpConversion<tosa::CastOp>>(ctx, "emitc::tosa::cast",
+                                               /*explicitResultType=*/true);
+  patterns.add<CallOpConversion<tosa::CeilOp>>(ctx, "emitc::tosa::ceil");
+  patterns.add<ClampOpConversion>(ctx);
+  patterns.add<CallOpConversion<tosa::ExpOp>>(ctx, "emitc::tosa::exp");
+  patterns.add<CallOpConversion<tosa::FloorOp>>(ctx, "emitc::tosa::floor");
+  patterns.add<CallOpConversion<tosa::LogOp>>(ctx, "emitc::tosa::log");
+  patterns.add<NegateOpConversion>(ctx);
+  patterns.add<CallOpConversion<tosa::ReciprocalOp>>(ctx,
+                                                     "emitc::tosa::reciprocal");
+  patterns.add<ReluNOpConversion>(ctx);
+  patterns.add<RsqrtOpConversion>(ctx);
+  patterns.add<CallOpConversion<tosa::TanhOp>>(ctx, "emitc::tosa::tanh");
 
   // Insert patterns for TOSA binary elementwise ops.
-  patterns.insert<CallOpBroadcastableConversion<tosa::AddOp>>(
-      ctx, "emitc::tosa::add");
-  patterns.insert<CallOpBroadcastableConversion<tosa::MaximumOp>>(
+  patterns.add<CallOpBroadcastableConversion<tosa::AddOp>>(ctx,
+                                                           "emitc::tosa::add");
+  patterns.add<CallOpBroadcastableConversion<tosa::MaximumOp>>(
       ctx, "emitc::tosa::maximum");
-  patterns.insert<CallOpBroadcastableConversion<tosa::MinimumOp>>(
+  patterns.add<CallOpBroadcastableConversion<tosa::MinimumOp>>(
       ctx, "emitc::tosa::minimum");
-  patterns.insert<MulOpConversion>(ctx, "emitc::tosa::mul");
-  patterns.insert<CallOpBroadcastableConversion<tosa::PowOp>>(
-      ctx, "emitc::tosa::pow");
-  patterns.insert<CallOpBroadcastableConversion<tosa::SubOp>>(
-      ctx, "emitc::tosa::sub");
+  patterns.add<MulOpConversion>(ctx, "emitc::tosa::mul");
+  patterns.add<CallOpBroadcastableConversion<tosa::PowOp>>(ctx,
+                                                           "emitc::tosa::pow");
+  patterns.add<CallOpBroadcastableConversion<tosa::SubOp>>(ctx,
+                                                           "emitc::tosa::sub");
 
   // Insert patterns for other TOSA ops.
-  patterns.insert<GenericConvOpConversion<tosa::Conv2DOp>>(
-      ctx, "emitc::tosa::conv2d");
-  patterns.insert<GenericConvOpConversion<tosa::DepthwiseConv2DOp>>(
+  patterns.add<GenericConvOpConversion<tosa::Conv2DOp>>(ctx,
+                                                        "emitc::tosa::conv2d");
+  patterns.add<GenericConvOpConversion<tosa::DepthwiseConv2DOp>>(
       ctx, "emitc::tosa::depthwise_conv2d");
-  patterns.insert<FullyConnectedOpConversion>(ctx,
-                                              "emitc::tosa::fully_connected");
-  patterns.insert<MatMulOpConversion>(ctx);
-  patterns.insert<ReduceOpConversion<tosa::ReduceAllOp>>(
+  patterns.add<FullyConnectedOpConversion>(ctx, "emitc::tosa::fully_connected");
+  patterns.add<MatMulOpConversion>(ctx);
+  patterns.add<ReduceOpConversion<tosa::ReduceAllOp>>(
       ctx, "emitc::tosa::reduce_all");
-  patterns.insert<ReduceOpConversion<tosa::ReduceAnyOp>>(
+  patterns.add<ReduceOpConversion<tosa::ReduceAnyOp>>(
       ctx, "emitc::tosa::reduce_any");
-  patterns.insert<ReduceOpConversion<tosa::ReduceMaxOp>>(
+  patterns.add<ReduceOpConversion<tosa::ReduceMaxOp>>(
       ctx, "emitc::tosa::reduce_max");
-  patterns.insert<ReduceOpConversion<tosa::ReduceMinOp>>(
+  patterns.add<ReduceOpConversion<tosa::ReduceMinOp>>(
       ctx, "emitc::tosa::reduce_min");
-  patterns.insert<ReduceOpConversion<tosa::ReduceProdOp>>(
+  patterns.add<ReduceOpConversion<tosa::ReduceProdOp>>(
       ctx, "emitc::tosa::reduce_prod");
-  patterns.insert<ReduceOpConversion<tosa::ReduceSumOp>>(
+  patterns.add<ReduceOpConversion<tosa::ReduceSumOp>>(
       ctx, "emitc::tosa::reduce_sum");
-  patterns.insert<CallOpConversion<tosa::ReshapeOp>>(
-      ctx, "emitc::tosa::reshape", /*explicitResultType=*/true);
-  patterns.insert<SliceOpConversion>(ctx);
-  patterns.insert<PadOpConversion>(ctx);
-  patterns.insert<CallOpConversion<tosa::TransposeOp>>(
+  patterns.add<CallOpConversion<tosa::ReshapeOp>>(ctx, "emitc::tosa::reshape",
+                                                  /*explicitResultType=*/true);
+  patterns.add<SliceOpConversion>(ctx);
+  patterns.add<PadOpConversion>(ctx);
+  patterns.add<CallOpConversion<tosa::TransposeOp>>(
       ctx, "emitc::tosa::transpose", /*explicitResultType=*/true);
 }
 
@@ -800,7 +799,7 @@ struct ConvertTosaToEmitCPass
                         tosa::TransposeOp>();
     // clang-format on
 
-    OwningRewritePatternList patterns(&getContext());
+    RewritePatternSet patterns(&getContext());
     populateTosaToEmitcPatterns(&getContext(), patterns);
 
     if (failed(


### PR DESCRIPTION
Renames OwningRewritePatternList to RewritePatternSet, as with upstream
commit llvm/llvm-project@dc4e913b. Also renames `patterns.insert` to
`patterns.add`.