### PR TITLE
Rename and refactor `forwardDeclareVariables`

### DIFF
--- a/include/emitc/Target/Cpp/CppEmitter.h
+++ b/include/emitc/Target/Cpp/CppEmitter.h
@@ -60,7 +60,7 @@ inline LogicalResult interleaveCommaWithError(const Container &c,
 /// Emitter that uses dialect specific emitters to emit C++ code.
 struct CppEmitter {
   explicit CppEmitter(raw_ostream &os, bool restrictToC,
-                      bool forwardDeclareVariables);
+                      bool declareVariablesAtTop);
 
   /// Emits attribute or returns failure.
   LogicalResult emitAttribute(Operation &op, Attribute attr);
@@ -147,8 +147,9 @@ struct CppEmitter {
   /// Returns if to emitc C.
   bool isRestrictedToC() { return restrictToC; };
 
-  /// Returns if all variables need to be forward declared.
-  bool forwardDeclaredVariables() { return forwardDeclareVariables; };
+  /// Returns if all variables for op results and basic block arguments need to
+  /// be declared at the beginning of a function.
+  bool shouldDeclareVariablesAtTop() { return declareVariablesAtTop; };
 
 private:
   using ValueMapper = llvm::ScopedHashTable<Value, std::string>;
@@ -160,8 +161,10 @@ private:
   /// Boolean that restricts the emitter to C.
   bool restrictToC;
 
-  /// Boolean to enforce a forward declaration of all variables.
-  bool forwardDeclareVariables;
+  /// Boolean to enforce that all variables for op results and block
+  /// arguments are declared at the beginning of the function. This also
+  /// includes results from ops located in nested regions.
+  bool declareVariablesAtTop;
 
   /// Map from value to name of C++ variable that contain the name.
   ValueMapper valueMapper;
@@ -178,12 +181,12 @@ private:
 /// Translates the given operation to C++ code. The operation or operations in
 /// the region of 'op' need almost all be in EmitC dialect.
 LogicalResult translateToCpp(Operation &op, raw_ostream &os,
-                             bool forwardDeclareVariables = false,
+                             bool declareVariablesAtTop = false,
                              bool trailingSemicolon = false);
 
 /// Similar to `translateToCpp`, but translates the given operation to C code.
 LogicalResult translateToC(Operation &op, raw_ostream &os,
-                           bool forwardDeclareVariables = false,
+                           bool declareVariablesAtTop = false,
                            bool trailingSemicolon = false);
 } // namespace emitc
 } // namespace mlir

--- a/lib/Target/Cpp/TranslateRegistration.cpp
+++ b/lib/Target/Cpp/TranslateRegistration.cpp
@@ -27,7 +27,7 @@ void registerToCppTranslation() {
       "mlir-to-cpp",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToCpp(*module.getOperation(), output,
-                                     /*forwardDeclareVariables=*/false,
+                                     /*declareVariablesAtTop=*/false,
                                      /*trailingSemiColon=*/false);
       },
       [](DialectRegistry &registry) {
@@ -39,10 +39,10 @@ void registerToCppTranslation() {
       });
 
   TranslateFromMLIRRegistration regForwardDeclared(
-      "mlir-to-cpp-forward-declared",
+      "mlir-to-cpp-with-variable-declarations-at-top",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToCpp(*module.getOperation(), output,
-                                     /*forwardDeclareVariables=*/true,
+                                     /*declareVariablesAtTop=*/true,
                                      /*trailingSemiColon=*/false);
       },
       [](DialectRegistry &registry) {
@@ -63,7 +63,7 @@ void registerToCTranslation() {
       "mlir-to-c",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToC(*module.getOperation(), output,
-                                   /*forwardDeclareVariables=*/false,
+                                   /*declareVariablesAtTop=*/false,
                                    /*trailingSemiColon=*/false);
       },
       [](DialectRegistry &registry) {
@@ -75,10 +75,10 @@ void registerToCTranslation() {
       });
 
   TranslateFromMLIRRegistration regForwardDeclared(
-      "mlir-to-c-forward-declared",
+      "mlir-to-c-with-variable-declarations-at-top",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToC(*module.getOperation(), output,
-                                   /*forwardDeclareVariables=*/true,
+                                   /*declareVariablesAtTop=*/true,
                                    /*trailingSemiColon=*/false);
       },
       [](DialectRegistry &registry) {

--- a/test/Target/Cpp/call-cpp.mlir
+++ b/test/Target/Cpp/call-cpp.mlir
@@ -1,7 +1,7 @@
 // This file contains tests for emitc call ops which are only supported if cpp code is emitted.
 
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @emitc_call() {
   %0 = constant 0 : index

--- a/test/Target/Cpp/call.mlir
+++ b/test/Target/Cpp/call.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -mlir-to-c %s | FileCheck %s -check-prefix=C-DEFAULT
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @emitc_call() {
   %0 = emitc.call "func_a" () : () -> i32

--- a/test/Target/Cpp/const.mlir
+++ b/test/Target/Cpp/const.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -mlir-to-c %s | FileCheck %s -check-prefix=C-DEFAULT
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 
 func @emitc_constant() {

--- a/test/Target/Cpp/control_flow.mlir
+++ b/test/Target/Cpp/control_flow.mlir
@@ -1,5 +1,5 @@
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 // simple(10, true)  -> 20
 // simple(10, false) -> 30

--- a/test/Target/Cpp/for.mlir
+++ b/test/Target/Cpp/for.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -mlir-to-c %s | FileCheck %s -check-prefix=C-DEFAULT
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
   scf.for %i0 = %arg0 to %arg1 step %arg2 {

--- a/test/Target/Cpp/if.mlir
+++ b/test/Target/Cpp/if.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -mlir-to-c %s | FileCheck %s -check-prefix=C-DEFAULT
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @test_if(%arg0: i1, %arg1: f32) {
   scf.if %arg0 {

--- a/test/Target/Cpp/invalid.mlir
+++ b/test/Target/Cpp/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -split-input-file -mlir-to-cpp -verify-diagnostics %s
 // RUN: emitc-translate -split-input-file -mlir-to-c -verify-diagnostics %s
 
-// expected-error@+1 {{'func' op with multiple blocks needs forward declared variables}}
+// expected-error@+1 {{'func' op with multiple blocks needs variables declared at top}}
 func @multiple_blocks() {
 ^bb1:
     br ^bb2

--- a/test/Target/Cpp/stdops-cpp.mlir
+++ b/test/Target/Cpp/stdops-cpp.mlir
@@ -1,7 +1,7 @@
 // This file contains tests for std ops which are only supported if cpp code is emitted.
 
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @std_constant() {
   %c0 = constant dense<0> : tensor<i32>

--- a/test/Target/Cpp/stdops.mlir
+++ b/test/Target/Cpp/stdops.mlir
@@ -1,7 +1,7 @@
 // RUN: emitc-translate -mlir-to-c %s | FileCheck %s -check-prefix=C-DEFAULT
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-c-forward-declared %s | FileCheck %s -check-prefix=C-FWDDECL
-// RUN: emitc-translate -mlir-to-cpp-forward-declared %s | FileCheck %s -check-prefix=CPP-FWDDECL
+// RUN: emitc-translate -mlir-to-c-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=C-FWDDECL
+// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-FWDDECL
 
 func @std_constant() {
   %c0 = constant 0 : i32


### PR DESCRIPTION
Renames `forwardDeclareVariables` to `declareVariablesAtTop`. Further
updates comments and refactors early returns.

Co-authored-by: Simon Camphausen <simon.camphausen@iml.fraunhofer.de>