### PR TITLE
Don't expose `trailingSemicolon` via translation

### DIFF
--- a/include/emitc/Target/Cpp/CppEmitter.h
+++ b/include/emitc/Target/Cpp/CppEmitter.h
@@ -174,8 +174,7 @@ private:
 /// Translates the given operation to C++ code. The operation or operations in
 /// the region of 'op' need almost all be in EmitC dialect.
 LogicalResult translateToCpp(Operation &op, raw_ostream &os,
-                             bool declareVariablesAtTop = false,
-                             bool trailingSemicolon = false);
+                             bool declareVariablesAtTop = false);
 } // namespace emitc
 } // namespace mlir
 

--- a/lib/Target/Cpp/TranslateRegistration.cpp
+++ b/lib/Target/Cpp/TranslateRegistration.cpp
@@ -27,8 +27,7 @@ void registerToCppTranslation() {
       "mlir-to-cpp",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToCpp(*module.getOperation(), output,
-                                     /*declareVariablesAtTop=*/false,
-                                     /*trailingSemiColon=*/false);
+                                     /*declareVariablesAtTop=*/false);
       },
       [](DialectRegistry &registry) {
         // clang-format off
@@ -42,8 +41,7 @@ void registerToCppTranslation() {
       "mlir-to-cpp-with-variable-declarations-at-top",
       [](ModuleOp module, raw_ostream &output) {
         return emitc::translateToCpp(*module.getOperation(), output,
-                                     /*declareVariablesAtTop=*/true,
-                                     /*trailingSemiColon=*/false);
+                                     /*declareVariablesAtTop=*/true);
       },
       [](DialectRegistry &registry) {
         // clang-format off

--- a/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/lib/Target/Cpp/TranslateToCpp.cpp
@@ -820,8 +820,7 @@ LogicalResult CppEmitter::emitTupleType(Operation &op, ArrayRef<Type> types) {
 }
 
 LogicalResult emitc::translateToCpp(Operation &op, raw_ostream &os,
-                                    bool declareVariablesAtTop,
-                                    bool trailingSemicolon) {
+                                    bool declareVariablesAtTop) {
   CppEmitter emitter(os, declareVariablesAtTop);
-  return emitter.emitOperation(op, trailingSemicolon);
+  return emitter.emitOperation(op, /*trailingSemicolon=*/false);
 }


### PR DESCRIPTION
There is no need to expose/pass through `trailingSemicolon` via
`translateToCpp()`.