### PR TITLE
Integrate LLVM at llvm/llvm-project@b36c4bb3

### DIFF
--- a/build_tools/llvm_version.txt
+++ b/build_tools/llvm_version.txt
@@ -1,1 +1,1 @@
-96e3fb2416f6ce9bae94313b30bdfeeaddb2de36
+b36c4bb3ecc954f8c78d21a3200fc8faaec240d0


### PR DESCRIPTION
Updates LLVM usage to match llvm/llvm-project@b36c4bb3.
Further updates the MLIR-HLO submodule to tensorflow/mlir-hlo@b67f34aa.