### PR TITLE
Refactor translation cmdline arguments

### DIFF
--- a/lib/Target/Cpp/TranslateRegistration.cpp
+++ b/lib/Target/Cpp/TranslateRegistration.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Translation.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace mlir;
 
@@ -23,25 +24,17 @@ namespace mlir {
 //===----------------------------------------------------------------------===//
 
 void registerToCppTranslation() {
+  static llvm::cl::opt<bool> declareVariablesAtTop(
+      "declare-variables-at-top",
+      llvm::cl::desc("Declare variables at top when emitting C/C++"),
+      llvm::cl::init(false));
+
   TranslateFromMLIRRegistration reg(
       "mlir-to-cpp",
       [](ModuleOp module, raw_ostream &output) {
-        return emitc::translateToCpp(module, output,
-                                     /*declareVariablesAtTop=*/false);
-      },
-      [](DialectRegistry &registry) {
-        // clang-format off
-        registry.insert<emitc::EmitCDialect,
-                        StandardOpsDialect,
-                        scf::SCFDialect>();
-        // clang-format on
-      });
-
-  TranslateFromMLIRRegistration regForwardDeclared(
-      "mlir-to-cpp-with-variable-declarations-at-top",
-      [](ModuleOp module, raw_ostream &output) {
-        return emitc::translateToCpp(module, output,
-                                     /*declareVariablesAtTop=*/true);
+        return emitc::translateToCpp(
+            module, output,
+            /*declareVariablesAtTop=*/declareVariablesAtTop);
       },
       [](DialectRegistry &registry) {
         // clang-format off

--- a/test/Target/Cpp/call.mlir
+++ b/test/Target/Cpp/call.mlir
@@ -1,5 +1,5 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func @emitc_call() {
   %0 = emitc.call "func_a" () : () -> i32

--- a/test/Target/Cpp/const.mlir
+++ b/test/Target/Cpp/const.mlir
@@ -1,5 +1,5 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 
 func @emitc_constant() {

--- a/test/Target/Cpp/control_flow.mlir
+++ b/test/Target/Cpp/control_flow.mlir
@@ -1,4 +1,4 @@
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 // simple(10, true)  -> 20
 // simple(10, false) -> 30

--- a/test/Target/Cpp/for.mlir
+++ b/test/Target/Cpp/for.mlir
@@ -1,5 +1,5 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func @test_for(%arg0 : index, %arg1 : index, %arg2 : index) {
   scf.for %i0 = %arg0 to %arg1 step %arg2 {

--- a/test/Target/Cpp/if.mlir
+++ b/test/Target/Cpp/if.mlir
@@ -1,5 +1,5 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func @test_if(%arg0: i1, %arg1: f32) {
   scf.if %arg0 {

--- a/test/Target/Cpp/stdops.mlir
+++ b/test/Target/Cpp/stdops.mlir
@@ -1,5 +1,5 @@
 // RUN: emitc-translate -mlir-to-cpp %s | FileCheck %s -check-prefix=CPP-DEFAULT
-// RUN: emitc-translate -mlir-to-cpp-with-variable-declarations-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
+// RUN: emitc-translate -mlir-to-cpp -declare-variables-at-top %s | FileCheck %s -check-prefix=CPP-DECLTOP
 
 func @std_constant() {
   %c0 = constant 0 : i32


### PR DESCRIPTION
Drops `mlir-to-cpp-with-variable-declarations-at-top` in favor of
passing the additional argument `declare-variables-at-top` in
adition to `mlir-to-cpp`.