### PR TITLE
Remove IREE build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,6 @@ if(EMITC_ENABLE_HLO)
   add_definitions(-DEMITC_BUILD_HLO)
 endif()
 
-if(IREE_ENABLE_EMITC)
-  message(STATUS "Building EmitC (with reduced deps) for use within IREE")
-  add_definitions(-DIREE_BUILD_EMITC)
-endif()
-
 #-------------------------------------------------------------------------------
 # MLIR/LLVM configuration
 #-------------------------------------------------------------------------------
@@ -68,14 +63,6 @@ add_definitions(${LLVM_DEFINITIONS})
 #-------------------------------------------------------------------------------
 # Dependent projects and dependencies
 #-------------------------------------------------------------------------------
-
-# If building as part of IREE, add IREE specific includes.
-if(IREE_ENABLE_EMITC AND IREE_MLIR_DEP_MODE STREQUAL "BUNDLED")
-  include_directories(${IREE_COMMON_INCLUDE_DIRS})
-elseif(IREE_ENABLE_EMITC AND IREE_MLIR_DEP_MODE STREQUAL "INSTALLED")
-  include_directories(${iree_SOURCE_DIR})
-  include_directories(${iree_BINARY_DIR})
-endif()
 
 # Configure MHLO if we are building standalone. If building as part of
 # another, let it handle the submodule and includes.

--- a/tools/emitc-opt/CMakeLists.txt
+++ b/tools/emitc-opt/CMakeLists.txt
@@ -1,37 +1,5 @@
-if(${IREE_ENABLE_EMITC})
-  # Dialects from iree::tools::init_mlir_passes_and_dialects
-  set(dialect_libs
-    MLIRAffine
-    MLIRAffineTransforms
-    MLIRGPU
-    MLIRIR
-    MLIRLLVMIR
-    MLIRLinalg
-    MLIRLinalgTransforms
-    MLIRQuant
-    MLIRSCF
-    MLIRSCFTransforms
-    MLIRSPIRV
-    MLIRSPIRVTransforms
-    MLIRShape
-    MLIRStandard
-    MLIRTosa
-    MLIRTosaTransforms
-    MLIRTransforms
-    MLIRVector
-    )
-  # Passes from iree::tools::init_mlir_passes_and_dialects
-  set(conversion_libs
-    MLIRGPUToSPIRV
-    MLIRLinalgToLLVM
-    MLIRLinalgToSPIRV
-    MLIRSCFToGPU
-    MLIRStandardToSPIRV
-    )
-else()
-  get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-  get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-endif()
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 if(${EMITC_ENABLE_HLO})
   set(HLO_LIBS

--- a/tools/emitc-opt/emitc-opt.cpp
+++ b/tools/emitc-opt/emitc-opt.cpp
@@ -12,10 +12,6 @@
 
 #include "emitc/InitDialect.h"
 #include "emitc/InitPasses.h"
-#ifdef IREE_BUILD_EMITC
-#include "iree/tools/init_mlir_dialects.h"
-#include "iree/tools/init_mlir_passes.h"
-#endif
 #ifdef EMITC_BUILD_HLO
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
@@ -25,10 +21,8 @@
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
-#ifndef IREE_BUILD_EMITC
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
-#endif
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
@@ -43,13 +37,8 @@ using namespace mlir;
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
-#ifdef IREE_BUILD_EMITC
-  registerMlirDialects(registry);
-  registerMlirPasses();
-#else
   registerAllDialects(registry);
   registerAllPasses();
-#endif // IREE_BUILD_EMITC
   registerEmitCDialect(registry);
   emitc::registerAllEmitCPasses();
 #ifdef EMITC_BUILD_HLO

--- a/tools/emitc-translate/CMakeLists.txt
+++ b/tools/emitc-translate/CMakeLists.txt
@@ -1,29 +1,8 @@
 set(LLVM_LINK_COMPONENTS
   Support
   )
-if(${IREE_ENABLE_EMITC})
-  # Dialects from iree::tools::init_mlir_passes_and_dialects
-  set(dialect_libs
-    MLIRAffine
-    MLIRAffineTransforms
-    MLIRGPU
-    MLIRIR
-    MLIRLLVMIR
-    MLIRLinalg
-    MLIRLinalgTransforms
-    MLIRQuant
-    MLIRSCF
-    MLIRSCFTransforms
-    MLIRSPIRV
-    MLIRSPIRVTransforms
-    MLIRStandard
-    MLIRShape
-    MLIRTransforms
-    MLIRVector
-    )
-else()
-  get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-endif()
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_llvm_executable(emitc-translate
   emitc-translate.cpp


### PR DESCRIPTION
IREE does no longer depend on mlir-emitc as a submodule.