### PR TITLE
Drop mhlo passes

### DIFF
--- a/tools/emitc-opt/CMakeLists.txt
+++ b/tools/emitc-opt/CMakeLists.txt
@@ -6,7 +6,7 @@ if(${EMITC_ENABLE_HLO})
     MLIRMHLOToEmitC
     MLIRMHLORegionOpsToEmitC
     MhloRegisterDialects
-    AllMhloPasses
+    MhloToStandard
     )
   set(HLO_LIBS_DEPS
     MLIREmitCConversionPassIncGen

--- a/tools/emitc-opt/emitc-opt.cpp
+++ b/tools/emitc-opt/emitc-opt.cpp
@@ -13,9 +13,7 @@
 #include "emitc/InitDialect.h"
 #include "emitc/InitPasses.h"
 #ifdef EMITC_BUILD_HLO
-#include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
-#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/register_passes.h"
 #endif
 #include "mlir/IR/AsmState.h"
@@ -42,11 +40,8 @@ int main(int argc, char **argv) {
   registerEmitCDialect(registry);
   emitc::registerAllEmitCPasses();
 #ifdef EMITC_BUILD_HLO
-  mhlo::registerAllMhloPasses();
-  lmhlo::registerAllLmhloPasses();
   registry.insert<mlir::mhlo::MhloDialect>();
-  registry.insert<mlir::chlo::HloClientDialect>();
-  registry.insert<mlir::lmhlo::LmhloDialect>();
+  mlir::mhlo::registerLegalizeControlFlowToScfPassPass();
 #endif // EMITC_BUILD_HLO
 
   return failed(MlirOptMain(argc, argv, "MLIR EmitC modular optimizer driver\n",


### PR DESCRIPTION
We only use the `mhlo-control-flow-to-scf` conversion pass from the
tensorflow/mlir-hlo repo. This drops all other mhlo passes.