### PR TITLE
Add Eigen based implementation of tosa conv2d op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 option(EMITC_BUILD_EMBEDDED "Build EmitC as part of another project" OFF)
 option(EMITC_ENABLE_HLO "Enables building MLIR-HLO." ON)
+option(EMITC_TOSA_ENABLE_EIGEN "Enables use of Eigen library for some TOSA Ops." OFF)
 option(EMITC_INCLUDE_TESTS "Generate build targets for the MLIR EmitC unit tests." ON)
 # TODO: Set to MLIR or LLVM default
 #       ${LLVM_INCLUDE_TESTS})
@@ -70,6 +71,17 @@ if(EMITC_ENABLE_HLO AND NOT EMITC_BUILD_EMBEDDED)
   add_subdirectory(third_party/mlir-hlo EXCLUDE_FROM_ALL)
   include_directories(${mlir-hlo_SOURCE_DIR}/include)
   include_directories(${mlir-hlo_BINARY_DIR}/include)
+endif()
+
+# Optional Eigen dependency for some TOSA Ops
+if(EMITC_TOSA_ENABLE_EIGEN)
+  find_package(Eigen3 3.3 NO_MODULE)
+  if(TARGET Eigen3::Eigen)
+    add_compile_definitions(EMITC_TOSA_ENABLE_EIGEN)
+  else()
+    message(WARNING "EMITC_TOSA_ENABLE_EIGEN is ON, but Eigen was not found.")
+    set(EMITC_TOSA_ENABLE_EIGEN OFF)
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/include/emitc/emitc_tosa.h
+++ b/include/emitc/emitc_tosa.h
@@ -20,6 +20,10 @@
 #include "emitc_core_ops.h"
 #include "emitc_std.h"
 
+#ifdef EMITC_TOSA_ENABLE_EIGEN
+#include "emitc_tosa_eigen.h"
+#endif
+
 namespace emitc {
 namespace tosa {
 
@@ -155,6 +159,8 @@ inline Src sub(Src x, Src y) {
 }
 
 /// Functions for other TOSA ops.
+// Disable Conv2DOp if Eigen implementation is used
+#ifndef EMITC_TOSA_ENABLE_EIGEN
 // Conv2DOp
 template <typename Dest, typename Src, typename Weights>
 Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
@@ -226,6 +232,7 @@ Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
 
   return output;
 }
+#endif
 
 // DepthwiseConv2DOp
 template <typename Dest, typename Src, typename Weights>

--- a/include/emitc/emitc_tosa_eigen.h
+++ b/include/emitc/emitc_tosa_eigen.h
@@ -1,0 +1,112 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines alternative implementations for the functions in
+// emitc_tosa.h utilizing Eigen.
+
+#ifndef EMITC_EMITC_TOSA_EIGEN_H
+#define EMITC_EMITC_TOSA_EIGEN_H
+
+#include "emitc_std.h"
+#include <unsupported/Eigen/CXX11/Tensor>
+
+namespace {
+
+// A view on an emitc tensor as Eigen tensor in row-major order
+template <typename T, size_t... Shape>
+inline auto as_eigen(Tensor<T, Shape...> &t) {
+  return Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<Shape...>, Eigen::RowMajor>>(
+      &*t.begin(), Shape...);
+}
+
+} // namespace
+
+namespace emitc {
+namespace tosa {
+
+// Conv2DOp
+template <typename Dest, typename Src, typename Weights>
+Dest conv2d(Src input, Weights weights, Tensor1D<int64_t, 4> padding,
+            Tensor1D<int64_t, 2> stride, Tensor1D<int64_t, 2> dilation) {
+  // Input is [N,IH,IW,IC], weights are [OC,KH,KW,IC] and output is [N,H,W,OC]
+  static_assert(is_tensor_of_dim<4, Src>::value,
+                "Expected 4 dimensional input");
+  static_assert(is_tensor_of_dim<4, Dest>::value,
+                "Expected 4 dimensional output");
+  static_assert(is_tensor_of_dim<4, Weights>::value,
+                "Expected 4 dimensional weights");
+
+  constexpr int N = Src::dim(0);
+  constexpr int IC = Src::dim(3);
+  constexpr int KF = Weights::dim(0);
+  constexpr int KH = Weights::dim(1);
+  constexpr int KW = Weights::dim(2);
+  constexpr int KC = Weights::dim(3);
+  constexpr int ON = Dest::dim(0);
+  constexpr int H = Dest::dim(1);
+  constexpr int W = Dest::dim(2);
+  constexpr int OC = Dest::dim(3);
+
+  static_assert(N == ON, "Expected input batch size to match output");
+  static_assert(IC == KC, "Expected input channels to match weights");
+  static_assert(OC == KF, "Expected output channels to match weights");
+
+  const int64_t pt = padding[0];
+  const int64_t pb = padding[1];
+  const int64_t pl = padding[2];
+  const int64_t pr = padding[3];
+  const int64_t SH = stride[0];
+  const int64_t SW = stride[1];
+  const int64_t DH = dilation[0];
+  const int64_t DW = dilation[1];
+
+  Dest output;
+  // [N,IH,IW,IC]
+  auto e_input = as_eigen(input);
+  // [KH,KW,IC,OC]
+  auto e_weight =
+      as_eigen(weights).shuffle(Eigen::array<Eigen::Index, 4>({1, 2, 3, 0}));
+  // [N,H,W,OC]
+  auto e_output = as_eigen(output);
+
+  // apply padding to input [N,IH+pt+pb,IW+pl+pr,IC]
+  auto input_pad = e_input.pad(Eigen::array<std::pair<int64_t, int64_t>, 4>{
+      std::make_pair(0, 0), std::make_pair(pt, pb), std::make_pair(pl, pr),
+      std::make_pair(0, 0)});
+
+  // create tensor containing input patches [N,H*W,KH,KW,IC]
+  auto patches = input_pad.extract_image_patches(KW, KH, SW, SH, DW, DH,
+                                                 Eigen::PADDING_VALID);
+
+  // create 2d tensor from patches [N*H*W,KH*KW*IC]
+  auto patches_m =
+      patches.reshape(Eigen::DSizes<int64_t, 2>{N * H * W, KH * KW * IC});
+
+  // create 2d tensor from weights [KH*KW*IC,OC]
+  auto weight_m = e_weight.reshape(Eigen::DSizes<int64_t, 2>{KH * KW * IC, OC});
+
+  // multiply [N*H*W,OC]
+  auto contr =
+      patches_m.contract(weight_m, Eigen::array<Eigen::IndexPair<int64_t>, 1>{
+                                       Eigen::IndexPair<int64_t>(1, 0)});
+
+  // reshape result to output [N,H,W,OC]
+  e_output = contr.reshape(Eigen::DSizes<int64_t, 4>{N, H, W, OC});
+
+  return output;
+}
+
+} // namespace tosa
+} // namespace emitc
+
+#endif // EMITC_EMITC_TOSA_EIGEN_H

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -15,3 +15,9 @@ target_include_directories(MLIREmitCAllTests
   PRIVATE ${gtest_SOURCE_DIR}/include
   PRIVATE ${gmock_SOURCE_DIR}/include
 )
+
+if(EMITC_TOSA_ENABLE_EIGEN)
+  target_include_directories(MLIREmitCAllTests
+    PRIVATE ${EIGEN3_INCLUDE_DIR}
+  )
+endif()


### PR DESCRIPTION
An optional replacement for the current implementation of the tosa conv2d op with better performance. Can be enabled using the CMake option `EMITC_TOSA_ENABLE_EIGEN`.