### PR TITLE
Replace `mhlo-control-flow-to-scf`

### DIFF
--- a/test/testCorrectGroundTruthWithHMC_canon_inline.mlir
+++ b/test/testCorrectGroundTruthWithHMC_canon_inline.mlir
@@ -1,5 +1,5 @@
-// RUN: emitc-opt %s --mhlo-control-flow-to-scf --convert-mhlo-to-emitc --convert-std-to-emitc --convert-arith-to-emitc --convert-tensor-to-emitc | emitc-translate --mlir-to-cpp
-// RUN: emitc-opt %s --mhlo-control-flow-to-scf --convert-mhlo-to-emitc --convert-std-to-emitc --convert-arith-to-emitc --convert-tensor-to-emitc --print-op-stats -o /dev/null 2>&1 | FileCheck %s
+// RUN: emitc-opt %s --mhlo-legalize-control-flow --convert-mhlo-to-emitc --convert-std-to-emitc --convert-arith-to-emitc --convert-tensor-to-emitc | emitc-translate --mlir-to-cpp --declare-variables-at-top
+// RUN: emitc-opt %s --mhlo-legalize-control-flow --convert-mhlo-to-emitc --convert-std-to-emitc --convert-arith-to-emitc --convert-tensor-to-emitc --print-op-stats -o /dev/null 2>&1 | FileCheck %s
 
 // CHECK: emitc.call
 // CHECK: emitc.constant

--- a/tools/emitc-opt/emitc-opt.cpp
+++ b/tools/emitc-opt/emitc-opt.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
   emitc::registerAllEmitCPasses();
 #ifdef EMITC_BUILD_HLO
   registry.insert<mlir::mhlo::MhloDialect>();
-  mlir::mhlo::registerLegalizeControlFlowToScfPassPass();
+  mlir::mhlo::registerLegalizeControlFlowPassPass();
 #endif // EMITC_BUILD_HLO
 
   return failed(MlirOptMain(argc, argv, "MLIR EmitC modular optimizer driver\n",


### PR DESCRIPTION
The `mhlo-control-flow-to-scf` is broken and dropped upstream with
commit tensorflow/mlir-hlo@/f5296af. With this commit we switch over to
use the `mhlo-legalize-control-flow` pass, similar to what IREE does.