### PR TITLE
Build unit tests without `add_mlir_unittest`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -145,9 +145,9 @@ jobs:
           -DCMAKE_CXX_COMPILER=clang++ \
           -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
         cmake --build . --target check-emitc -- -j$(nproc)
-        cmake --build . --target MLIREmitCAllTests -- -j$(nproc)
+        cmake --build . --target MLIREmitCTests -- -j$(nproc)
         cmake --build . --target MLIREmitCEigenTests -- -j$(nproc)
-        ./unittests/MLIREmitCAllTests
+        ./unittests/MLIREmitCTests
         ./unittests/MLIREmitCEigenTests
 
   build-release:
@@ -194,9 +194,9 @@ jobs:
           -DCMAKE_CXX_COMPILER=clang++ \
           -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
         cmake --build . --target check-emitc -- -j$(nproc)
-        cmake --build . --target MLIREmitCAllTests -- -j$(nproc)
+        cmake --build . --target MLIREmitCTests -- -j$(nproc)
         cmake --build . --target MLIREmitCEigenTests -- -j$(nproc)
-        ./unittests/MLIREmitCAllTests
+        ./unittests/MLIREmitCTests
         ./unittests/MLIREmitCEigenTests
 
     - name: Cache e2e

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ cmake --build . --target check-emitc
 
 To additionally build and execute the unittests, run
 ```shell
-cmake --build . --target MLIREmitCAllTests
-./unittests/MLIREmitCAllTests
+cmake --build . --target MLIREmitCTests
+./unittests/MLIREmitCTests
 ```
 
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,33 +1,28 @@
-set(LLVM_OPTIONAL_SOURCES
-  emitc_mhlo.cpp
-  emitc_arith.cpp
-  emitc_std.cpp
-  emitc_tensor.cpp
-  emitc_tosa_eigen.cpp
-  emitc_tosa.cpp
-  emitc_types.cpp
+add_executable(MLIREmitCTests "")
+target_sources(MLIREmitCTests
+  PRIVATE
+    emitc_mhlo.cpp
+    emitc_arith.cpp
+    emitc_std.cpp
+    emitc_tensor.cpp
+    emitc_tosa_eigen.cpp
+    emitc_tosa.cpp
+    emitc_types.cpp
 )
 
-add_custom_target(MLIREmitCUnitTests)
-set_target_properties(MLIREmitCUnitTests PROPERTIES FOLDER "MLIR EmitC Tests")
-
-function(add_mlir_unittest test_dirname)
-  add_unittest(MLIREmitCUnitTests ${test_dirname} ${ARGN})
-endfunction()
-
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
-add_mlir_unittest(MLIREmitCAllTests emitc_mhlo.cpp emitc_arith.cpp emitc_std.cpp emitc_tensor.cpp emitc_tosa.cpp emitc_tosa_eigen.cpp emitc_types.cpp)
-
-target_include_directories(MLIREmitCAllTests
+target_include_directories(MLIREmitCTests
   PRIVATE ${gtest_SOURCE_DIR}/include
   PRIVATE ${gmock_SOURCE_DIR}/include
 )
 
+target_link_libraries(MLIREmitCTests PRIVATE gtest_main gtest)
+
 if(EMITC_TOSA_TEST_EIGEN)
-  add_mlir_unittest(MLIREmitCEigenTests emitc_tosa_eigen.cpp)
+  add_executable(MLIREmitCEigenTests "")
+  target_sources(MLIREmitCEigenTests
+    PRIVATE
+      emitc_tosa_eigen.cpp
+  )
 
   target_compile_definitions(MLIREmitCEigenTests PRIVATE EMITC_TOSA_USE_EIGEN)
 
@@ -36,5 +31,5 @@ if(EMITC_TOSA_TEST_EIGEN)
     PRIVATE ${gmock_SOURCE_DIR}/include
   )
 
-  target_link_libraries(MLIREmitCEigenTests PRIVATE Eigen3::Eigen)
+  target_link_libraries(MLIREmitCEigenTests PRIVATE Eigen3::Eigen gtest_main gtest)
 endif()


### PR DESCRIPTION
In preparation to move the EmitC header-only reference implementation
to its own CMake project, unit tests are now build with pure CMake.