### PR TITLE
Always include `emitc_tosa.h`

### DIFF
--- a/unittests/emitc_tosa_eigen.cpp
+++ b/unittests/emitc_tosa_eigen.cpp
@@ -12,12 +12,7 @@
 
 #include "gmock/gmock.h"
 
-#ifdef EMITC_TOSA_USE_EIGEN
-#include "emitc/emitc_tosa_eigen.h"
-#else
 #include "emitc/emitc_tosa.h"
-#endif
-
 #include "emitc/emitc_types.h"
 
 namespace {


### PR DESCRIPTION
If `EMITC_TOSA_USE_EIGEN` is defined is already checked in the
`emitc_tosa.h` itself, which then includes `emitc_tosa_eigen.h`.