### PR TITLE
Introduce EMITC_TOSA_USE_EIGEN build option

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -143,7 +143,8 @@ jobs:
           -DCMAKE_LINKER=lld \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
-          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
+          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit \
+          -DEMITC_TOSA_USE_EIGEN=ON
         cmake --build . --target check-emitc -- -j$(nproc)
         cmake --build . --target MLIREmitCTests -- -j$(nproc)
         cmake --build . --target MLIREmitCEigenTests -- -j$(nproc)
@@ -192,7 +193,8 @@ jobs:
           -DCMAKE_LINKER=lld \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
-          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit
+          -DLLVM_EXTERNAL_LIT=`pwd`/../../${LLVM}/build/bin/llvm-lit \
+          -DEMITC_TOSA_USE_EIGEN=ON
         cmake --build . --target check-emitc -- -j$(nproc)
         cmake --build . --target MLIREmitCTests -- -j$(nproc)
         cmake --build . --target MLIREmitCEigenTests -- -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,17 @@ set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 
+include(CMakeDependentOption)
+
 #-------------------------------------------------------------------------------
 # Options and definitions
 #-------------------------------------------------------------------------------
 
 option(EMITC_BUILD_EMBEDDED "Build EmitC as part of another project" OFF)
 option(EMITC_ENABLE_HLO "Enables building MLIR-HLO." ON)
-option(EMITC_TOSA_TEST_EIGEN "Enables testing of Eigen library for some TOSA Ops." ON)
+option(EMITC_TOSA_USE_EIGEN "Enables use of Eigen library for some TOSA Ops." OFF)
 option(EMITC_INCLUDE_TESTS "Generate build targets for the MLIR EmitC unit tests." ON)
+cmake_dependent_option(EMITC_TOSA_TEST_EIGEN "Enables testing of Eigen library for some TOSA Ops." ON "EMITC_INCLUDE_TESTS;EMITC_TOSA_USE_EIGEN" OFF)
 # TODO: Set to MLIR or LLVM default
 #       ${LLVM_INCLUDE_TESTS})
 
@@ -74,11 +77,10 @@ if(EMITC_ENABLE_HLO AND NOT EMITC_BUILD_EMBEDDED)
 endif()
 
 # Optional Eigen dependency for some TOSA Ops
-if(EMITC_TOSA_TEST_EIGEN)
+if(EMITC_TOSA_USE_EIGEN)
   find_package(Eigen3 3.3.1 NO_MODULE)
   if(NOT TARGET Eigen3::Eigen)
-    message(WARNING "Should test with Eigen, but Eigen was not found.")
-    set(EMITC_TOSA_TEST_EIGEN OFF)
+    message(FATAL_ERROR "Should build with Eigen, but Eigen was not found.")
   endif()
 endif()
 

--- a/include/emitc/CMakeLists.txt
+++ b/include/emitc/CMakeLists.txt
@@ -22,7 +22,7 @@ target_sources(EmitCRefImpl
 )
 set_target_properties(EmitCRefImpl PROPERTIES LINKER_LANGUAGE CXX)
 
-if(EMITC_TOSA_TEST_EIGEN)
+if(EMITC_TOSA_USE_EIGEN)
     add_library(EmitCRefImpl_Eigen INTERFACE)
     target_sources(EmitCRefImpl_Eigen
     INTERFACE


### PR DESCRIPTION
Allows to set building and testing with Eigen separately.