### PR TITLE
Replace deprecated FunctionPass

### DIFF
--- a/include/emitc/Dialect/EmitC/Conversion/Passes.h
+++ b/include/emitc/Dialect/EmitC/Conversion/Passes.h
@@ -20,11 +20,11 @@ namespace emitc {
 
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertMhloRegionOpsToEmitCPass();
-std::unique_ptr<FunctionPass> createConvertMhloToEmitCPass();
-std::unique_ptr<FunctionPass> createConvertArithToEmitCPass();
-std::unique_ptr<FunctionPass> createConvertStdToEmitCPass();
-std::unique_ptr<FunctionPass> createConvertTensorToEmitCPass();
-std::unique_ptr<FunctionPass> createConvertTosaToEmitCPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertMhloToEmitCPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertArithToEmitCPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertStdToEmitCPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertTensorToEmitCPass();
+std::unique_ptr<OperationPass<FuncOp>> createConvertTosaToEmitCPass();
 
 #define GEN_PASS_REGISTRATION
 #include "emitc/Dialect/EmitC/Conversion/Passes.h.inc"

--- a/include/emitc/Dialect/EmitC/Conversion/Passes.td
+++ b/include/emitc/Dialect/EmitC/Conversion/Passes.td
@@ -17,31 +17,31 @@ def ConvertMHLORegionOpsToEmitC : Pass<"convert-mhlo-region-ops-to-emitc", "Modu
   let dependentDialects = ["EmitCDialect"];
 }
 
-def ConvertMHLOToEmitC : FunctionPass<"convert-mhlo-to-emitc"> {
+def ConvertMHLOToEmitC : Pass<"convert-mhlo-to-emitc", "FuncOp"> {
   let summary = "Convert from MHLO dialect to EmitC dialect.";
   let constructor = "createConvertMhloToEmitCPass()";
   let dependentDialects = ["EmitCDialect"];
 }
 
-def ConvertArithToEmitC : FunctionPass<"convert-arith-to-emitc"> {
+def ConvertArithToEmitC : Pass<"convert-arith-to-emitc", "FuncOp"> {
   let summary = "Convert arith dialect to EmitC dialect, replacing IndexCastOp.";
   let constructor = "createConvertArithToEmitCPass()";
   let dependentDialects = ["EmitCDialect"];
 }
 
-def ConvertStdToEmitC : FunctionPass<"convert-std-to-emitc"> {
+def ConvertStdToEmitC : Pass<"convert-std-to-emitc", "FuncOp"> {
   let summary = "Convert std dialect to EmitC dialect, replacing SplatOp.";
   let constructor = "createConvertStdToEmitCPass()";
   let dependentDialects = ["EmitCDialect"];
 }
 
-def ConvertTensorToEmitC : FunctionPass<"convert-tensor-to-emitc"> {
+def ConvertTensorToEmitC : Pass<"convert-tensor-to-emitc", "FuncOp"> {
   let summary = "Convert tensor dialect to EmitC dialect, replacing ExtractOp.";
   let constructor = "createConvertTensorToEmitCPass()";
   let dependentDialects = ["EmitCDialect"];
 }
 
-def ConvertTosaToEmitC : FunctionPass<"convert-tosa-to-emitc"> {
+def ConvertTosaToEmitC : Pass<"convert-tosa-to-emitc", "FuncOp"> {
   let summary = "Convert TOSA dialect to EmitC dialect.";
   let constructor = "createConvertTosaToEmitCPass()";
   let dependentDialects = ["EmitCDialect"];

--- a/lib/Dialect/EmitC/Conversion/ArithToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/ArithToEmitC.cpp
@@ -61,7 +61,7 @@ namespace {
 struct ConvertArithToEmitCPass
     : public ConvertArithToEmitCBase<ConvertArithToEmitCPass> {
   /// Perform the lowering to EmitC dialect.
-  void runOnFunction() override {
+  void runOnOperation() override {
 
     ConversionTarget target(getContext());
 
@@ -72,14 +72,15 @@ struct ConvertArithToEmitCPass
     RewritePatternSet patterns(&getContext());
     populateArithToEmitcPatterns(&getContext(), patterns);
 
-    if (failed(
-            applyPartialConversion(getFunction(), target, std::move(patterns))))
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
       signalPassFailure();
   }
 };
 
 } // namespace
 
-std::unique_ptr<FunctionPass> mlir::emitc::createConvertArithToEmitCPass() {
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::emitc::createConvertArithToEmitCPass() {
   return std::make_unique<ConvertArithToEmitCPass>();
 }

--- a/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
@@ -579,7 +579,7 @@ namespace {
 struct ConvertMhloToEmitCPass
     : public ConvertMHLOToEmitCBase<ConvertMhloToEmitCPass> {
   /// Perform the lowering to EmitC dialect.
-  void runOnFunction() override {
+  void runOnOperation() override {
 
     ConversionTarget target(getContext());
 
@@ -657,14 +657,15 @@ struct ConvertMhloToEmitCPass
     RewritePatternSet patterns(&getContext());
     populateMhloToEmitcPatterns(&getContext(), patterns);
 
-    if (failed(
-            applyPartialConversion(getFunction(), target, std::move(patterns))))
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
       signalPassFailure();
   }
 };
 
 } // namespace
 
-std::unique_ptr<FunctionPass> mlir::emitc::createConvertMhloToEmitCPass() {
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::emitc::createConvertMhloToEmitCPass() {
   return std::make_unique<ConvertMhloToEmitCPass>();
 }

--- a/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/StdToEmitC.cpp
@@ -59,7 +59,7 @@ namespace {
 struct ConvertStdToEmitCPass
     : public ConvertStdToEmitCBase<ConvertStdToEmitCPass> {
   /// Perform the lowering to EmitC dialect.
-  void runOnFunction() override {
+  void runOnOperation() override {
 
     ConversionTarget target(getContext());
 
@@ -70,14 +70,15 @@ struct ConvertStdToEmitCPass
     RewritePatternSet patterns(&getContext());
     populateStdToEmitcPatterns(&getContext(), patterns);
 
-    if (failed(
-            applyPartialConversion(getFunction(), target, std::move(patterns))))
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
       signalPassFailure();
   }
 };
 
 } // namespace
 
-std::unique_ptr<FunctionPass> mlir::emitc::createConvertStdToEmitCPass() {
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::emitc::createConvertStdToEmitCPass() {
   return std::make_unique<ConvertStdToEmitCPass>();
 }

--- a/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TensorToEmitC.cpp
@@ -65,7 +65,7 @@ namespace {
 struct ConvertTensorToEmitCPass
     : public ConvertTensorToEmitCBase<ConvertTensorToEmitCPass> {
   /// Perform the lowering to EmitC dialect.
-  void runOnFunction() override {
+  void runOnOperation() override {
 
     ConversionTarget target(getContext());
 
@@ -75,14 +75,15 @@ struct ConvertTensorToEmitCPass
     RewritePatternSet patterns(&getContext());
     populateTensorToEmitcPatterns(&getContext(), patterns);
 
-    if (failed(
-            applyPartialConversion(getFunction(), target, std::move(patterns))))
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
       signalPassFailure();
   }
 };
 
 } // namespace
 
-std::unique_ptr<FunctionPass> mlir::emitc::createConvertTensorToEmitCPass() {
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::emitc::createConvertTensorToEmitCPass() {
   return std::make_unique<ConvertTensorToEmitCPass>();
 }

--- a/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/TosaToEmitC.cpp
@@ -807,7 +807,7 @@ namespace {
 struct ConvertTosaToEmitCPass
     : public ConvertTosaToEmitCBase<ConvertTosaToEmitCPass> {
   /// Perform the lowering to EmitC dialect.
-  void runOnFunction() override {
+  void runOnOperation() override {
 
     ConversionTarget target(getContext());
 
@@ -863,14 +863,15 @@ struct ConvertTosaToEmitCPass
     RewritePatternSet patterns(&getContext());
     populateTosaToEmitcPatterns(&getContext(), patterns);
 
-    if (failed(
-            applyPartialConversion(getFunction(), target, std::move(patterns))))
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
       signalPassFailure();
   }
 };
 
 } // namespace
 
-std::unique_ptr<FunctionPass> mlir::emitc::createConvertTosaToEmitCPass() {
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::emitc::createConvertTosaToEmitCPass() {
   return std::make_unique<ConvertTosaToEmitCPass>();
 }


### PR DESCRIPTION
Replaces the deprecated FunctionPass in favor of OperationPass<FuncOp>.
This is changed upstream with commit llvm/llvm-project@4157455.