### PR TITLE
Update tosa pad with explicit padding value

### DIFF
--- a/reference-implementation/include/emitc/tosa.h
+++ b/reference-implementation/include/emitc/tosa.h
@@ -578,7 +578,9 @@ Dest slice(Src x, Tensor<int64_t, Src::rank()> start_indices,
 
 // PadOp
 template <typename Dest, typename Src, typename Padding>
-inline Dest pad(Src operand, Padding padding) {
+inline Dest pad(Src operand, Padding padding,
+                Tensor0D<typename get_element_type<Src>::type> pad_const =
+                    Tensor0D<typename get_element_type<Src>::type>{0}) {
   using ET_Padding = typename get_element_type<Padding>::type;
 
   static_assert(is_tensor<Dest>::value, "Expected tensor result");
@@ -609,8 +611,8 @@ inline Dest pad(Src operand, Padding padding) {
   Tensor<int64_t, Src::rank()> interior_padding;
   std::fill(interior_padding.begin(), interior_padding.end(), 0);
 
-  return emitc::pad<Dest>(operand, {0}, edge_padding_low, edge_padding_high,
-                          interior_padding);
+  return emitc::pad<Dest>(operand, pad_const, edge_padding_low,
+                          edge_padding_high, interior_padding);
 }
 
 // TransposeOp

--- a/reference-implementation/unittests/tosa.cpp
+++ b/reference-implementation/unittests/tosa.cpp
@@ -643,52 +643,130 @@ TEST(tosa, slice) {
 
 TEST(tosa, pad) {
   // clang-format off
-  Tensor<int32_t, 2, 3> operand0{1, 2, 3,
-                                 4, 5, 6};
-  Tensor<int32_t, 2, 2, 3> operand1{1, 2, 3,  4,  5,  6,
-                                    7, 8, 9, 10, 11, 12};
-
-  Tensor<int32_t, 2, 2> padding0{0, 1,
-                                 1, 2};
-  Tensor<int32_t, 3, 2> padding1_0{0, 0,
-                                   0, 0,
-                                   0, 0};
-  Tensor<int32_t, 3, 2> padding1_1{1, 1,
-                                   1, 1,
-                                   1, 1};
-  Tensor<int32_t, 3, 2> padding1_2{1, 0,
-                                   0, 1,
-                                   1, 0};
-
-  Tensor<int32_t, 3, 6> expected_result0{0, 1, 2, 3, 0, 0,
-                                         0, 4, 5, 6, 0, 0,
-                                         0, 0, 0, 0, 0, 0};
-  Tensor<int32_t, 2, 2, 3> expected_result1_0{1, 2, 3,  4,  5,  6,
-                                              7, 8, 9, 10, 11, 12};
-  Tensor<int32_t, 4, 4, 5> expected_result1_1{
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0,  4,  5,  6,  0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 7, 8, 9, 0, 0, 10, 11, 12,  0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0, 0, 0, 0, 0};
-  Tensor<int32_t, 3, 3, 4> expected_result1_2{
-      0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0,
-      0, 1, 2, 3, 0,  4,  5,  6, 0, 0, 0, 0,
-      0, 7, 8, 9, 0, 10, 11, 12, 0, 0, 0, 0};
-
+  Tensor2D<int32_t, 2, 3> operand0{1, 2, 3,
+                                   4, 5, 6};
+  Tensor3D<int32_t, 2, 2, 3> operand1{1, 2, 3,  4,  5,  6,
+                                      7, 8, 9, 10, 11, 12};
   // clang-format on
-  Tensor<int32_t, 3, 6> result0 =
-      tosa::pad<Tensor<int32_t, 3, 6>>(operand0, padding0);
-  Tensor<int32_t, 2, 2, 3> result1_0 =
-      tosa::pad<Tensor<int32_t, 2, 2, 3>>(operand1, padding1_0);
-  Tensor<int32_t, 4, 4, 5> result1_1 =
-      tosa::pad<Tensor<int32_t, 4, 4, 5>>(operand1, padding1_1);
-  Tensor<int32_t, 3, 3, 4> result1_2 =
-      tosa::pad<Tensor<int32_t, 3, 3, 4>>(operand1, padding1_2);
 
-  EXPECT_THAT(result0, Pointwise(Eq(), expected_result0));
-  EXPECT_THAT(result1_0, Pointwise(Eq(), expected_result1_0));
-  EXPECT_THAT(result1_1, Pointwise(Eq(), expected_result1_1));
-  EXPECT_THAT(result1_2, Pointwise(Eq(), expected_result1_2));
+  {
+    // clang-format off
+    Tensor2D<int32_t, 2, 2> padding{0, 1,
+                                    1, 2};
+    Tensor2D<int32_t, 3, 6> expected_result{0, 1, 2, 3, 0, 0,
+                                            0, 4, 5, 6, 0, 0,
+                                            0, 0, 0, 0, 0, 0};
+    // clang-format on
+    Tensor2D<int32_t, 3, 6> result =
+        tosa::pad<Tensor2D<int32_t, 3, 6>>(operand0, padding);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  { // explicit value
+    // clang-format off
+    Tensor2D<int32_t, 2, 2> padding{0, 1,
+                                    1, 2};
+    Tensor0D<int32_t> pad_const{1};
+    Tensor2D<int32_t, 3, 6> expected_result{1, 1, 2, 3, 1, 1,
+                                            1, 4, 5, 6, 1, 1,
+                                            1, 1, 1, 1, 1, 1};
+    // clang-format on
+    Tensor2D<int32_t, 3, 6> result =
+        tosa::pad<Tensor2D<int32_t, 3, 6>>(operand0, padding, pad_const);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{0, 0,
+                                    0, 0,
+                                    0, 0};
+    Tensor3D<int32_t, 2, 2, 3> expected_result{1, 2, 3,  4,  5,  6,
+                                               7, 8, 9, 10, 11, 12};
+    // clang-format on
+    Tensor3D<int32_t, 2, 2, 3> result =
+        tosa::pad<Tensor3D<int32_t, 2, 2, 3>>(operand1, padding);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  { // explicit value
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{0, 0,
+                                    0, 0,
+                                    0, 0};
+    Tensor0D<int32_t> pad_const{1};
+    Tensor3D<int32_t, 2, 2, 3> expected_result{1, 2, 3,  4,  5,  6,
+                                               7, 8, 9, 10, 11, 12};
+    // clang-format on
+    Tensor3D<int32_t, 2, 2, 3> result =
+        tosa::pad<Tensor3D<int32_t, 2, 2, 3>>(operand1, padding, pad_const);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{1, 1,
+                                    1, 1,
+                                    1, 1};
+    Tensor3D<int32_t, 4, 4, 5> expected_result{
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0,  4,  5,  6,  0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 7, 8, 9, 0, 0, 10, 11, 12,  0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0, 0, 0, 0, 0};
+    // clang-format on
+    Tensor3D<int32_t, 4, 4, 5> result =
+        tosa::pad<Tensor3D<int32_t, 4, 4, 5>>(operand1, padding);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  { // explicit value
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{1, 1,
+                                    1, 1,
+                                    1, 1};
+    Tensor0D<int32_t> pad_const{-1};
+    Tensor3D<int32_t, 4, 4, 5> expected_result{
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  -1,  -1,  -1,  -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1,  1,  2,  3, -1, -1,   4,   5,   6,  -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1,  7,  8,  9, -1, -1,  10,  11,  12,  -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  -1,  -1,  -1,  -1, -1, -1, -1, -1, -1};
+    // clang-format on
+    Tensor3D<int32_t, 4, 4, 5> result =
+        tosa::pad<Tensor3D<int32_t, 4, 4, 5>>(operand1, padding, pad_const);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{1, 0,
+                                    0, 1,
+                                    1, 0};
+    Tensor3D<int32_t, 3, 3, 4> expected_result{
+        0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0,
+        0, 1, 2, 3, 0,  4,  5,  6, 0, 0, 0, 0,
+        0, 7, 8, 9, 0, 10, 11, 12, 0, 0, 0, 0};
+    // clang-format on
+    Tensor3D<int32_t, 3, 3, 4> result =
+        tosa::pad<Tensor3D<int32_t, 3, 3, 4>>(operand1, padding);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  { // explicit value
+    // clang-format off
+    Tensor2D<int32_t, 3, 2> padding{1, 0,
+                                    0, 1,
+                                    1, 0};
+    Tensor0D<int32_t> pad_const{3};
+    Tensor3D<int32_t, 3, 3, 4> expected_result{
+        3, 3, 3, 3, 3,  3,  3,  3, 3, 3, 3, 3,
+        3, 1, 2, 3, 3,  4,  5,  6, 3, 3, 3, 3,
+        3, 7, 8, 9, 3, 10, 11, 12, 3, 3, 3, 3};
+    // clang-format on
+    Tensor3D<int32_t, 3, 3, 4> result =
+        tosa::pad<Tensor3D<int32_t, 3, 3, 4>>(operand1, padding, pad_const);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
 }
 
 TEST(tosa, transpose) {

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -292,6 +292,14 @@ func @test_pad(%arg0: tensor<2x3xf32>, %arg1: tensor<2x2xi32>) -> tensor<3x6xf32
   return %0 : tensor<3x6xf32>
 }
 
+func @test_pad_explicit_value(%arg0: tensor<2x3xf32>, %arg1: tensor<2x2xi32>) -> tensor<3x6xf32> {
+  // CHECK: %0 = "emitc.constant"() {value = dense<3.140000e+00> : tensor<f32>} : () -> tensor<f32>
+  %0 = "tosa.const"() {value = dense<3.14> : tensor<f32>} : () -> tensor<f32>
+  // CHECK-NEXT: %1 = emitc.call "emitc::tosa::pad"(%arg0, %arg1, %0) {template_args = [tensor<3x6xf32>]} : (tensor<2x3xf32>, tensor<2x2xi32>, tensor<f32>) -> tensor<3x6xf32>
+  %1 = "tosa.pad"(%arg0, %arg1, %0) : (tensor<2x3xf32>, tensor<2x2xi32>, tensor<f32>) -> tensor<3x6xf32>
+  return %1 : tensor<3x6xf32>
+}
+
 func @test_reshape(%arg0: tensor<13x21x3xf32>) -> tensor<1x819xf32> {
   // CHECK: %0 = emitc.call "emitc::tosa::reshape"(%arg0) {template_args = [tensor<1x819xf32>]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>
   %0 = "tosa.reshape"(%arg0) {new_shape = [1, 819]} : (tensor<13x21x3xf32>) -> tensor<1x819xf32>


### PR DESCRIPTION
Adds the new optional parameter to the tosa pad operation, that was
added with tosa spec 0.23

Co-authored-by: Benjamin Heidebroek <benjamin.heidebroek@iml.fraunhofer.de>