### PR TITLE
Drop support for `mhlo.rng_bit_generator`

### DIFF
--- a/reference-implementation/include/emitc/mhlo.h
+++ b/reference-implementation/include/emitc/mhlo.h
@@ -646,36 +646,6 @@ inline Dest rng_uniform(Tensor<T> low, Tensor<T> high,
   return z;
 }
 
-// RngBitGeneratorOp
-template <typename Dest, int32_t RngAlgorithm>
-Dest rng_bit_generator(typename std::tuple_element<0, Dest>::type state) {
-  // TODO: Implement correct algorithm; starting point would be
-  // https://github.com/tensorflow/tensorflow/blob/6f59650012f8904745dffaba540afc794c6613be/tensorflow/compiler/xla/service/rng_bit_generator_expander.cc#L56
-
-  using StateType = typename std::tuple_element<0, Dest>::type;
-  using TensorType = typename std::tuple_element<1, Dest>::type;
-  using T = typename TensorType::value_type;
-
-  StateType newState(state);
-
-  T minValue = std::numeric_limits<T>::min();
-  T maxValue = std::numeric_limits<T>::max();
-
-  Tensor<T> min{minValue};
-  Tensor<T> max{maxValue};
-
-  std::array<size_t, TensorType::rank()> arrayShape = TensorType::shape();
-  Tensor<int64_t, TensorType::rank()> tensorShape;
-
-  for (size_t i = 0; i < TensorType::rank(); i++) {
-    tensorShape[i] = static_cast<int64_t>(arrayShape[i]);
-  }
-
-  TensorType data = rng_uniform<TensorType, T>(min, max, tensorShape);
-
-  return std::make_tuple(newState, data);
-}
-
 // BatchNormInferenceOp
 template <typename Src, typename Feature>
 Src batch_norm_inference(Src input, Feature scale, Feature offset, Feature mean,

--- a/test/Conversion/mhlo-to-emitc.mlir
+++ b/test/Conversion/mhlo-to-emitc.mlir
@@ -417,14 +417,3 @@ func @mhlo_rng_uniform() -> () {
   %1 = "mhlo.rng_uniform"(%cst_2, %cst_3, %cst_4) : (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<17xf32>
   return
 }
-
-func @mhlo_rng_bit_generator() -> () {
-  %cst = "arith.constant"() {value = dense<2> : tensor<3xui64>} : () -> tensor<3xui64>
-
-  // CHECK: emitc.call "emitc::mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x2xui32>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
-  %0 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
-  
-  // CHECK: emitc.call "emitc::mhlo::rng_bit_generator"(%cst) {template_args = [tuple<tensor<3xui64>, tensor<2x7x3xf64>>, 2 : i32]} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
-  %1 = "mhlo.rng_bit_generator"(%cst) {rng_algorithm = 2 : i32} : (tensor<3xui64>) -> tuple<tensor<3xui64>, tensor<2x7x3xf64>>
-  return
-}


### PR DESCRIPTION
Drops the conversion and reference implementation for the
`mhlo.rng_bit_generator` op. The op is modified by upstream with commit
tensorflow/mlir-hlo@80ebc34 and was not properly supported within our
reference implementation anyway.