### PR TITLE
Clean up leftover of `convert-std-to-emitc`

### DIFF
--- a/include/emitc/Dialect/EmitC/Conversion/Passes.h
+++ b/include/emitc/Dialect/EmitC/Conversion/Passes.h
@@ -22,7 +22,6 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createConvertMhloRegionOpsToEmitCPass();
 std::unique_ptr<OperationPass<FuncOp>> createConvertMhloToEmitCPass();
 std::unique_ptr<OperationPass<FuncOp>> createConvertArithToEmitCPass();
-std::unique_ptr<OperationPass<FuncOp>> createConvertStdToEmitCPass();
 std::unique_ptr<OperationPass<FuncOp>> createConvertTensorToEmitCPass();
 std::unique_ptr<OperationPass<FuncOp>> createConvertTosaToEmitCPass();
 


### PR DESCRIPTION
The `convert-std-to-emitc` pass was removed.