### PR TITLE
Expand `mhlo::select` and refactor unit tests

### DIFF
--- a/reference-implementation/include/emitc/mhlo.h
+++ b/reference-implementation/include/emitc/mhlo.h
@@ -601,6 +601,17 @@ inline Src select(typename replace_element_type<bool, Src>::type pred,
 }
 
 template <typename Src, IsTensor<Src> = true>
+inline Src select(Tensor<bool> pred, Src on_true, Src on_false) {
+  Src z;
+
+  for (size_t i = 0; i < Src::size(); i++) {
+    z[i] = pred[0] ? on_true[i] : on_false[i];
+  }
+
+  return z;
+}
+
+template <typename Src, IsTensor<Src> = true>
 inline Src select(typename replace_element_type<bool, Src>::type pred,
                   Src on_true, Src on_false) {
   Src z;

--- a/reference-implementation/unittests/mhlo.cpp
+++ b/reference-implementation/unittests/mhlo.cpp
@@ -1880,35 +1880,36 @@ TEST(mhlo, select) {
   EXPECT_EQ(-1, mhlo::select(true, -1, 3));
   EXPECT_EQ(3, mhlo::select(false, -1, 3));
 
-  Tensor0D<int> s0{-3};
-  Tensor0D<int> t0{8};
-  Tensor0D<bool> p0{true};
+  {
+    Tensor0D<int> s{-3};
+    Tensor0D<int> t{8};
+    Tensor0D<bool> p{true};
 
-  auto lambda_0d = [&p0, &s0, &t0]() -> Tensor0D<int> {
-    return mhlo::select<Tensor0D<int>>(p0, s0, t0);
-  };
+    Tensor0D<int> expected_result{-3};
+    Tensor0D<int> result = mhlo::select<Tensor0D<int>>(p, s, t);
 
-  EXPECT_THAT(lambda_0d(), Pointwise(Eq(), {-3}));
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    Tensor1D<float, 2> s{-1.3f, 2.4f};
+    Tensor1D<float, 2> t{0.2f, -3.7f};
+    Tensor1D<bool, 2> p{true, false};
 
-  Tensor1D<float, 2> s1{-1.3f, 2.4f};
-  Tensor1D<float, 2> t1{0.2f, -3.7f};
-  Tensor1D<bool, 2> p1{true, false};
+    Tensor1D<float, 2> expected_result{-1.3f, -3.7f};
+    Tensor1D<float, 2> result = mhlo::select<Tensor1D<float, 2>>(p, s, t);
 
-  auto lambda_1d = [&p1, &s1, &t1]() -> Tensor1D<float, 2> {
-    return mhlo::select<Tensor1D<float, 2>>(p1, s1, t1);
-  };
+    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
+  }
+  {
+    Tensor2D<long, 2, 2> s{3, 1, 4, 9};
+    Tensor2D<long, 2, 2> t{-2, 8, 6, -10};
+    Tensor2D<bool, 2, 2> p{false, true, true, false};
 
-  EXPECT_THAT(lambda_1d(), Pointwise(FloatEq(), {-1.3f, -3.7f}));
+    Tensor2D<long, 2, 2> expected_result{-2, 1, 4, -10};
+    Tensor2D<long, 2, 2> result = mhlo::select<Tensor2D<long, 2, 2>>(p, s, t);
 
-  Tensor2D<long, 2, 2> s2{3, 1, 4, 9};
-  Tensor2D<long, 2, 2> t2{-2, 8, 6, -10};
-  Tensor2D<bool, 2, 2> p2{false, true, true, false};
-
-  auto lambda_2d = [&p2, &s2, &t2]() -> Tensor2D<long, 2, 2> {
-    return mhlo::select<Tensor2D<long, 2, 2>>(p2, s2, t2);
-  };
-
-  EXPECT_THAT(lambda_2d(), Pointwise(Eq(), {-2, 1, 4, -10}));
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
 }
 
 } // namespace

--- a/reference-implementation/unittests/mhlo.cpp
+++ b/reference-implementation/unittests/mhlo.cpp
@@ -1901,11 +1901,31 @@ TEST(mhlo, select) {
     EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
   }
   {
+    Tensor1D<float, 2> s{-1.3f, 2.4f};
+    Tensor1D<float, 2> t{0.2f, -3.7f};
+    Tensor0D<bool> p{true};
+
+    Tensor1D<float, 2> expected_result = s;
+    Tensor1D<float, 2> result = mhlo::select<Tensor1D<float, 2>>(p, s, t);
+
+    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
+  }
+  {
     Tensor2D<long, 2, 2> s{3, 1, 4, 9};
     Tensor2D<long, 2, 2> t{-2, 8, 6, -10};
     Tensor2D<bool, 2, 2> p{false, true, true, false};
 
     Tensor2D<long, 2, 2> expected_result{-2, 1, 4, -10};
+    Tensor2D<long, 2, 2> result = mhlo::select<Tensor2D<long, 2, 2>>(p, s, t);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    Tensor2D<long, 2, 2> s{3, 1, 4, 9};
+    Tensor2D<long, 2, 2> t{-2, 8, 6, -10};
+    Tensor0D<bool> p{false};
+
+    Tensor2D<long, 2, 2> expected_result = t;
     Tensor2D<long, 2, 2> result = mhlo::select<Tensor2D<long, 2, 2>>(p, s, t);
 
     EXPECT_THAT(result, Pointwise(Eq(), expected_result));

--- a/test/Conversion/mhlo-to-emitc.mlir
+++ b/test/Conversion/mhlo-to-emitc.mlir
@@ -398,6 +398,10 @@ func @mhlo_select(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>, %arg2: tensor<2xi1
   return %1 : tensor<2xf32>
 }
 
+func @select_scalar_pred(%arg0: tensor<i1>, %arg1: tensor<2x3xi32>, %arg2: tensor<2x3xi32>) -> tensor<2x3xi32> {
+  %0 = "mhlo.select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
+  return %0 : tensor<2x3xi32>
+}
 
 // RNG ops
 


### PR DESCRIPTION
According to
https://www.tensorflow.org/mlir/hlo_ops#mhloselect_mlirmhloselectop the
tensor of pred may be a scalar in which case it is broadcasted. Instead
of broadcasting we keep it a 0D tensor and overload the reference
implementation with a function that handles it accordingly.

Fixes #280