### PR TITLE
Pin protobuf to version 3.20.1

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,2 @@
 tf-nightly==2.10.0.dev20220519
+protobuf==3.20.1


### PR DESCRIPTION
The pipeline fails with newer protobuf versions:

```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```