### PR TITLE
Fix running lit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ endif()
 # `-Wcovered-switch-default` flag.
 string(REPLACE "-Wcovered-switch-default" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+set(EMITC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(EMITC_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(EMITC_MAIN_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(EMITC_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 include_directories(${LLVM_INCLUDE_DIRS})

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -28,8 +28,8 @@ config.host_ldflags = '@HOST_LDFLAGS@'
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
-config.emitc_src_root = "@CMAKE_SOURCE_DIR@"
-config.emitc_obj_root = "@CMAKE_BINARY_DIR@"
+config.emitc_src_root = "@EMITC_SOURCE_DIR@"
+config.emitc_obj_root = "@EMITC_BINARY_DIR@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
@@ -46,4 +46,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/test/lit.cfg.py")
+lit_config.load_config(config, "@EMITC_SOURCE_DIR@/test/lit.cfg.py")


### PR DESCRIPTION
Fixes running the lit tests if building as an in-tree-build via the
`LLVM_EXTERNAL_PROJECTS` mechanism.