### PR TITLE
Pin protobuf to version 3.19.4

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
 tf-nightly==2.10.0.dev20220519
-protobuf==3.20.1
+protobuf==3.19.4


### PR DESCRIPTION
A fresh install of tf-nightly==2.10.0.dev20220519 fails with:
`
ERROR: tb-nightly 2.10.0a20220712 has requirement protobuf<3.20,>=3.9.2, but you'll have protobuf 3.20.0 which is incompatible.
`