### PR TITLE
Integrate LLVM at llvm/llvm-project@131dda9

### DIFF
--- a/build_tools/llvm_version.txt
+++ b/build_tools/llvm_version.txt
@@ -1,1 +1,1 @@
-af1328ef452b9eaa4e9f0bc115aeda8f40c4bbff
+131dda9acc6978aba4740d75ca45f411fbabd726

--- a/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
+++ b/lib/Dialect/EmitC/Conversion/MHLOToEmitC.cpp
@@ -299,7 +299,8 @@ private:
     ArrayAttr args;
     ArrayAttr templateArgs = rewriter.getArrayAttr(
         {TypeAttr::get(elementType),
-         emitc::OpaqueAttr::get(ctx, functionName.getValue())});
+         emitc::OpaqueAttr::get(ctx, NoneType::get(ctx),
+                                functionName.getValue())});
 
     rewriter.replaceOpWithNewOp<emitc::CallOp>(compareOp, compareOp.getType(),
                                                callee, args, templateArgs,


### PR DESCRIPTION
Updates LLVM usage to match llvm/llvm-project@131dda9.
Further updates the MLIR-HLO submodule to tensorflow/mlir-hlo@817776b.