### PR TITLE
Update C++ standard to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(mlir-emitc LANGUAGES CXX C)
 set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include(CMakeDependentOption)
 


### PR DESCRIPTION
Sets the C++ standard to C++17 as LLVM does with revision
https://reviews.llvm.org/D130689.