### PR TITLE
Remove ReluN conversion and implementation

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -17,7 +17,6 @@ The table below shows the supported TOSA ops.
 | log                    | :heavy_check_mark: | |
 | negate                 | :heavy_check_mark: | |
 | reciprocal             | :heavy_check_mark: | |
-| reluN                  | :heavy_check_mark: | |
 | rescale                | :heavy_check_mark: | |
 | rsqrt                  | :heavy_check_mark: | |
 | tanh                   | :heavy_check_mark: | |

--- a/reference-implementation/include/emitc/tosa.h
+++ b/reference-implementation/include/emitc/tosa.h
@@ -108,14 +108,6 @@ inline Src reciprocal(Src x) {
   return unary<Src>(x, f);
 }
 
-// ReluNOp
-template <typename Src>
-inline Src reluN(Src operand, typename Src::value_type max_value) {
-  Tensor<typename Src::value_type> min{0};
-  Tensor<typename Src::value_type> max{max_value};
-  return emitc::clamp(min, operand, max);
-}
-
 // RescaleOp
 template <typename Dest, size_t Dim, typename Src>
 inline Dest rescale(Src x, typename get_element_type<Src>::type in_zp,

--- a/reference-implementation/unittests/tosa.cpp
+++ b/reference-implementation/unittests/tosa.cpp
@@ -80,6 +80,60 @@ TEST(tosa, clamp) {
 
     EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
   }
+
+  // These are the tests of the former ReluN operation, which has been removed
+  // from the TOSA specification. clamp with min_value=0 can be used instead.
+  {
+    Tensor0D<int32_t> operand{0};
+    int32_t max_value = 0;
+    Tensor0D<int32_t> expected_result{0};
+    Tensor0D<int32_t> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    Tensor0D<int32_t> operand{0};
+    int32_t max_value = 0;
+    Tensor0D<int32_t> expected_result{0};
+    Tensor0D<int32_t> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    Tensor1D<double, 2> operand{-4.7, 1.3};
+    double max_value = 1.4;
+    Tensor1D<double, 2> expected_result{0, 1.3};
+    Tensor1D<double, 2> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(DoubleEq(), expected_result));
+  }
+  {
+    Tensor2D<float, 2, 2> operand{0.0f, -9.9f, 4.4f, 8.8f};
+    float max_value = 5.5f;
+    Tensor2D<float, 2, 2> expected_result{0.0f, 0.0f, 4.4f, 5.5f};
+    Tensor2D<float, 2, 2> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
+  }
+  {
+    Tensor3D<int64_t, 3, 2, 1> operand{4, 1, -1, 3, 0, 2};
+    int64_t max_value = 3;
+    Tensor3D<int64_t, 3, 2, 1> expected_result{3, 1, 0, 3, 0, 2};
+    Tensor3D<int64_t, 3, 2, 1> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    Tensor4D<int16_t, 1, 2, 3, 2> operand{7812,  15481,  -30284, 30996,
+                                          18736, 6699,   31903,  26229,
+                                          15931, -18954, -27643, 19133};
+    int16_t max_value = 20000;
+    Tensor4D<int16_t, 1, 2, 3, 2> expected_result{
+        7812, 15481, 0, 20000, 18736, 6699, 20000, 20000, 15931, 0, 0, 19133};
+    Tensor4D<int16_t, 1, 2, 3, 2> result = tosa::clamp(operand, {0}, max_value);
+
+    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
+  }
 }
 
 TEST(tosa, clz) {
@@ -242,52 +296,6 @@ TEST(tosa, rescale) {
             x, in_zp, out_zp, mult, shift, scale32, double_round, per_channel);
 
     EXPECT_THAT(result, Pointwise(Eq(), expected_result));
-  }
-}
-
-TEST(tosa, reluN) {
-  {
-    Tensor0D<int32_t> operand{0};
-    int32_t max_value = 0;
-    Tensor0D<int32_t> expected_result{0};
-    Tensor0D<int32_t> result = tosa::reluN(operand, max_value);
-
-    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
-  }
-  {
-    Tensor1D<double, 2> operand{-4.7, 1.3};
-    double max_value = 1.4;
-    Tensor1D<double, 2> expected_result{0, 1.3};
-    Tensor1D<double, 2> result = tosa::reluN(operand, max_value);
-
-    EXPECT_THAT(result, Pointwise(DoubleEq(), expected_result));
-  }
-  {
-    Tensor2D<float, 2, 2> operand{0.0f, -9.9f, 4.4f, 8.8f};
-    float max_value = 5.5f;
-    Tensor2D<float, 2, 2> expected_result{0.0f, 0.0f, 4.4f, 5.5f};
-    Tensor2D<float, 2, 2> result = tosa::reluN(operand, max_value);
-
-    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
-  }
-  {
-    Tensor3D<int64_t, 3, 2, 1> operand{4, 1, -1, 3, 0, 2};
-    int64_t max_value = 3;
-    Tensor3D<int64_t, 3, 2, 1> expected_result{3, 1, 0, 3, 0, 2};
-    Tensor3D<int64_t, 3, 2, 1> result = tosa::reluN(operand, max_value);
-
-    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
-  }
-  {
-    Tensor4D<int16_t, 1, 2, 3, 2> operand{7812,  15481,  -30284, 30996,
-                                          18736, 6699,   31903,  26229,
-                                          15931, -18954, -27643, 19133};
-    int16_t max_value = 20000;
-    Tensor4D<int16_t, 1, 2, 3, 2> expected_result{
-        7812, 15481, 0, 20000, 18736, 6699, 20000, 20000, 15931, 0, 0, 19133};
-    Tensor4D<int16_t, 1, 2, 3, 2> result = tosa::reluN(operand, max_value);
-
-    EXPECT_THAT(result, Pointwise(FloatEq(), expected_result));
   }
 }
 

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -326,27 +326,3 @@ func.func @test_transpose(%arg0: tensor<13x21x3xf32>) -> tensor<3x13x21xf32> {
   %1 = "tosa.transpose"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3xi32>) -> tensor<3x13x21xf32>
   return %1 : tensor<3x13x21xf32>
 }
-
-func.func @test_relu0(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
-  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 3.40282347E+38 : f32]} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-  %0 = "tosa.reluN"(%arg0) {max_fp = 3.40282347E+38 : f32, max_int = 0 : i64} : (tensor<13x21x3xf32>) -> tensor<13x21x3xf32>
-  return %0 : tensor<13x21x3xf32>
-}
-
-func.func @test_relu1(%arg0: tensor<13x21x3xi64>) -> tensor<13x21x3xi64> {
-  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 255]} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
-  %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi64>) -> tensor<13x21x3xi64>
-  return %0 : tensor<13x21x3xi64>
-}
-
-func.func @test_relu2(%arg0: tensor<13x21x3xi32>) -> tensor<13x21x3xi32> {
-  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 255 : i32]} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
-  %0 = "tosa.reluN"(%arg0) {max_fp = 0.0 : f32, max_int = 255 : i64} : (tensor<13x21x3xi32>) -> tensor<13x21x3xi32>
-  return %0 : tensor<13x21x3xi32>
-}
-
-func.func @test_relu3(%arg0: tensor<13x21x3xf16>) -> tensor<13x21x3xf16> {
-  // CHECK: %0 = emitc.call "emitc::tosa::reluN"(%arg0) {args = [0 : index, 1.500000e+00 : f16]} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
-  %0 = "tosa.reluN"(%arg0) {max_fp = 1.5 : f32, max_int = 0 : i64} : (tensor<13x21x3xf16>) -> tensor<13x21x3xf16>
-  return %0 : tensor<13x21x3xf16>
-}


### PR DESCRIPTION
The ReluN operator was removed from the TOSA spec and the MLIR op is
removed with llvm/llvm-project@9dec80b. This patch therefore drops the
conversion to EmitC as well as the reference implementation. The latter
already relied on clamp. Hence, tests are moved instead of dropped.