### PR TITLE
Update actions and pin to commit

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout EmitC
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.EMITC }}
         submodules: 'true'
@@ -32,14 +32,14 @@ jobs:
 
     - name: Cache LLVM
       id: cache-llvm
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.LLVM }}
         key: ${{ runner.os }}-llvm-20.04-install-${{ env.llvm_hash }}
 
     - name: Checkout LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         repository: llvm/llvm-project
         path: ${{ env.LLVM }}
@@ -71,14 +71,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout EmitC
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.EMITC }}
         submodules: 'false'
 
     - name: Cache e2e
       id: cache-e2e
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.E2E }}
         key: ${{ runner.os }}-e2e-${{ hashFiles('emitc/scripts/*.py', 'emitc/scripts/requirements.txt', 'emitc/scripts/e2e*.sh') }}-${{ env.E2E_VERSION }}
@@ -117,7 +117,7 @@ jobs:
       run: sudo apt-get install -y libeigen3-dev
 
     - name: Checkout EmitC
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.EMITC }}
         submodules: 'true'
@@ -129,7 +129,7 @@ jobs:
 
     - name: Cache LLVM
       id: cache-llvm
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.LLVM }}
         key: ${{ runner.os }}-llvm-20.04-install-${{ env.llvm_hash }}
@@ -167,7 +167,7 @@ jobs:
       run: sudo apt-get install -y libeigen3-dev
 
     - name: Checkout EmitC
-      uses: actions/checkout@v2
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       with:
         path: ${{ env.EMITC }}
         submodules: 'true'
@@ -179,7 +179,7 @@ jobs:
 
     - name: Cache LLVM
       id: cache-llvm
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.LLVM }}
         key: ${{ runner.os }}-llvm-20.04-install-${{ env.llvm_hash }}
@@ -206,7 +206,7 @@ jobs:
         ./reference-implementation/unittests/MLIREmitCEigenTests
 
     - name: Cache e2e
-      uses: actions/cache@v2
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # v3.0.8
       with:
         path: ${{ env.E2E }}
         key: ${{ runner.os }}-e2e-${{ hashFiles('emitc/scripts/*.py', 'emitc/scripts/requirements.txt', 'emitc/scripts/e2e*.sh') }}-${{ env.E2E_VERSION }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"


### PR DESCRIPTION
This updates the used actions to newer versions and specifies a specific
commit instead of a tag or a branch, which can be overwritten by a
maintainer of the action.