### PR TITLE
Implement tosa lowerings for gather, select and concat ops.

### DIFF
--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -38,8 +38,8 @@ The table below shows the supported TOSA ops.
 | concat                 | :heavy_check_mark: | |
 | conv2d                 | :white_check_mark: | Quantization and dilation not supported |
 | depthwise_conv2d       | :white_check_mark: | Quantization and dilation not supported |
-| gather                 | :heavy_check_mark: | |
 | fully_connected        | :white_check_mark: | Quantization not supported |
+| gather                 | :heavy_check_mark: | |
 | matmul                 | :white_check_mark: | Quantization not supported |
 | reduce_all             | :heavy_check_mark: | |
 | reduce_any             | :heavy_check_mark: | |

--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -31,10 +31,14 @@ The table below shows the supported TOSA ops.
 | pow                    | :heavy_check_mark: | |
 | sub                    | :heavy_check_mark: | |
 | table                  | :heavy_check_mark: | |
+| **Ternary elementwise ops**
+| argmax                 | :heavy_check_mark: | |
 | **Other ops**
 | argmax                 | :heavy_check_mark: | |
+| concat                 | :heavy_check_mark: | |
 | conv2d                 | :white_check_mark: | Quantization and dilation not supported |
 | depthwise_conv2d       | :white_check_mark: | Quantization and dilation not supported |
+| gather                 | :heavy_check_mark: | |
 | fully_connected        | :white_check_mark: | Quantization not supported |
 | matmul                 | :white_check_mark: | Quantization not supported |
 | reduce_all             | :heavy_check_mark: | |

--- a/docs/tosa-op-coverage.md
+++ b/docs/tosa-op-coverage.md
@@ -32,7 +32,7 @@ The table below shows the supported TOSA ops.
 | sub                    | :heavy_check_mark: | |
 | table                  | :heavy_check_mark: | |
 | **Ternary elementwise ops**
-| argmax                 | :heavy_check_mark: | |
+| select                 | :heavy_check_mark: | |
 | **Other ops**
 | argmax                 | :heavy_check_mark: | |
 | concat                 | :heavy_check_mark: | |

--- a/lib/Conversion/TosaToEmitC/TosaToEmitC.cpp
+++ b/lib/Conversion/TosaToEmitC/TosaToEmitC.cpp
@@ -458,7 +458,6 @@ createBroadcastOpIfNeeded(SrcOp &srcOp, Adaptor adaptor,
   Value output = srcOp.getResult();
   auto opOutputShape = output.getType().cast<RankedTensorType>().getShape();
   auto opOutputRank = output.getType().cast<RankedTensorType>().getRank();
-  size_t operands = srcOp.getNumOperands();
   SmallVector<Value> broadcastedOperands;
 
   for (auto operand : adaptor.getOperands()) {

--- a/reference-implementation/include/emitc/core_ops.h
+++ b/reference-implementation/include/emitc/core_ops.h
@@ -335,6 +335,57 @@ Dest batch_matmul(Lhs lhs, Rhs rhs) {
   return output;
 }
 
+// ConcatenateOp
+template <int64_t Dimension, typename Dest, typename Src>
+inline Dest concatenate(Src input) {
+  Dest z = input;
+  return z;
+}
+
+template <int64_t Dimension, typename Dest, typename Src1, typename... Src>
+inline Dest concatenate(Src1 input1, Src... inputs) {
+  static_assert(sizeof...(inputs) > 0, "Wrong template specialization chosen");
+
+  // Concatenate all but the first input.
+  // We need to build the correct return type for the rest of the inputs.
+  using ET_Src = typename get_element_type<Src1>::type;
+  using Rest = typename concat<Dimension, ET_Src, Src...>::type;
+  Rest rest = concatenate<Dimension, Rest, Src...>(inputs...);
+
+  Dest z;
+
+  // a: AxBxI    xD
+  // b: AxBxJ    xD
+  // c: AxBx(I+J)xD
+
+  // repeat repeat until a_ptr == a.end():
+  //    copy IxD elements from a_ptr to c_ptr
+  //    move a_ptr, c_ptr by IxD elements
+  //    copy JxD elements from b_ptr to c_ptr
+  //    move b_ptr, c_ptr by JxD elements
+
+  // Take the product of all dimensions, starting at `Dimension`.
+  auto calculate_shift = [](const auto &shape) {
+    size_t shift = 1;
+    for (size_t i = Dimension; i < shape.size(); i++) {
+      shift *= shape[i];
+    }
+    return shift;
+  };
+  auto a_shift = calculate_shift(Src1::shape());
+  auto b_shift = calculate_shift(Rest::shape());
+
+  for (auto a_ptr = input1.begin(), b_ptr = rest.begin(), c_ptr = z.begin();
+       a_ptr != input1.end(); a_ptr += a_shift, b_ptr += b_shift) {
+    std::copy(a_ptr, a_ptr + a_shift, c_ptr);
+    c_ptr += a_shift;
+    std::copy(b_ptr, b_ptr + b_shift, c_ptr);
+    c_ptr += b_shift;
+  }
+
+  return z;
+}
+
 // ReshapeOp
 template <typename Dest, typename Src>
 inline Dest reshape(Src x) {

--- a/reference-implementation/include/emitc/mhlo.h
+++ b/reference-implementation/include/emitc/mhlo.h
@@ -308,11 +308,6 @@ inline Dest concatenate(Src... inputs) {
   return emitc::concatenate<Dimension, Dest, Src...>(inputs...);
 }
 
-template <int64_t Dimension, typename Dest, typename Src1, typename... Src>
-inline Dest concatenate(Src1 input1, Src... inputs) {
-  return emitc::concatenate<Dimension, Dest, Src1, Src...>(input1, inputs...);
-}
-
 // SliceOp
 template <typename Dest, typename Src>
 Dest slice(Src x, Tensor<int64_t, Src::rank()> start_indices,

--- a/reference-implementation/include/emitc/tosa.h
+++ b/reference-implementation/include/emitc/tosa.h
@@ -270,7 +270,30 @@ inline Tensor<int32_t, Shape...> table(Tensor<int16_t, Shape...> x,
   return unary<Tensor<int32_t, Shape...>>(x, f);
 }
 
+/// Functions for ternary elementwise TOSA ops.
+template <typename Dest, typename SrcPred, typename SrcOperand>
+inline Dest select(SrcPred a, SrcOperand b, SrcOperand c) {
+  using ET_Src_Pred = typename get_element_type<SrcPred>::type;
+  static_assert(std::is_same<ET_Src_Pred, bool>::value,
+                "Pred tensor type must be bool");
+  using ET_Src_Operand = typename get_element_type<SrcOperand>::type;
+  auto f = [](ET_Src_Pred pred, ET_Src_Operand on_true,
+              ET_Src_Operand on_false) { return pred ? on_true : on_false; };
+  return ternary<Dest, SrcPred, SrcOperand, SrcOperand>(a, b, c, f);
+}
+
 /// Functions for other TOSA ops.
+// ConcatOp
+template <int32_t Dimension, typename Dest, typename... Src>
+inline Dest concat(Src... inputs) {
+  return emitc::concatenate<Dimension, Dest, Src...>(inputs...);
+}
+
+template <int32_t Dimension, typename Dest, typename Src1, typename... Src>
+inline Dest concat(Src1 input1, Src... inputs) {
+  return emitc::concatenate<Dimension, Dest, Src1, Src...>(input1, inputs...);
+}
+
 // Disable Conv2DOp if Eigen implementation is used
 #ifndef EMITC_TOSA_USE_EIGEN
 // Conv2DOp
@@ -473,6 +496,33 @@ Dest fully_connected(Src input, Weights weights, Bias bias) {
     }
   }
   return output;
+}
+
+// GatherOp
+template <typename Dest, typename Src, typename Idx,
+          IsTensorOfDim<3, Dest> = true, IsTensorOfDim<3, Src> = true,
+          IsTensorOfDim<2, Idx> = true, IsTensorOfType<Idx, int32_t> = true>
+Dest gather(Src input, Idx indices) {
+  Dest result;
+  static_assert(input.dim(0) == result.dim(0),
+                "Input and output batch dimension do not match.");
+  static_assert(input.dim(0) == indices.dim(0),
+                "Input and weight batch dimension do not match.");
+  static_assert(input.dim(2) == result.dim(2),
+                "Input and output channel dimension do not match.");
+  static_assert(indices.dim(1) == result.dim(1),
+                "Weight and output index dimension do not match.");
+
+  auto it = result.begin();
+  size_t d0offset = Src::dim(1) * Src::dim(2);
+  for (int64_t i = 0, idx = Idx::size(); i < idx; i++) {
+    auto d0 = d0offset * (i / Idx::dim(1));
+    auto d1 = Src::dim(2) * indices[i];
+    auto start = input.begin() + d0 + d1;
+    auto end = start + Src::dim(2);
+    it = std::copy(start, end, it);
+  }
+  return result;
 }
 
 // MatMulOp

--- a/reference-implementation/include/emitc/tosa.h
+++ b/reference-implementation/include/emitc/tosa.h
@@ -289,11 +289,6 @@ inline Dest concat(Src... inputs) {
   return emitc::concatenate<Dimension, Dest, Src...>(inputs...);
 }
 
-template <int32_t Dimension, typename Dest, typename Src1, typename... Src>
-inline Dest concat(Src1 input1, Src... inputs) {
-  return emitc::concatenate<Dimension, Dest, Src1, Src...>(input1, inputs...);
-}
-
 // Disable Conv2DOp if Eigen implementation is used
 #ifndef EMITC_TOSA_USE_EIGEN
 // Conv2DOp
@@ -515,7 +510,7 @@ Dest gather(Src input, Idx indices) {
 
   auto it = result.begin();
   size_t d0offset = Src::dim(1) * Src::dim(2);
-  for (int64_t i = 0, idx = Idx::size(); i < idx; i++) {
+  for (size_t i = 0, idx = Idx::size(); i < idx; i++) {
     auto d0 = d0offset * (i / Idx::dim(1));
     auto d1 = Src::dim(2) * indices[i];
     auto start = input.begin() + d0 + d1;

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -292,6 +292,34 @@ inline Dest binary(const SrcLeft &x, const SrcRight &y, BinaryOp &&op) {
   return z;
 }
 
+template <typename Dest, typename SrcA, typename SrcB, typename SrcC,
+          typename TernaryOp, IsScalar<SrcA> = true, IsScalar<SrcB> = true,
+          IsScalar<SrcC> = true>
+inline Dest ternary(const SrcA &a, const SrcB &b, const SrcB &c,
+                    TernaryOp &&op) {
+  return op(a, b, c);
+}
+
+template <typename Dest, typename SrcA, typename SrcB, typename SrcC,
+          typename TernaryOp, IsTensor<SrcA> = true, IsTensor<SrcB> = true,
+          IsTensor<SrcC> = true>
+inline Dest ternary(const SrcA &a, const SrcB &b, const SrcB &c,
+                    TernaryOp &&op) {
+  Dest d;
+  auto first1 = a.begin(), last1 = a.end();
+  auto first2 = b.begin(), first3 = c.begin();
+  auto result = d.begin();
+
+  while (first1 != last1) {
+    *result = op(*first1, *first2, *first3);
+    result++;
+    first1++;
+    first2++;
+    first3++;
+  }
+  return d;
+}
+
 template <size_t Dim, typename T, typename... Ts>
 struct concat {};
 

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -312,10 +312,10 @@ inline Dest ternary(const SrcA &a, const SrcB &b, const SrcB &c,
 
   while (first1 != last1) {
     *result = op(*first1, *first2, *first3);
-    result++;
-    first1++;
-    first2++;
-    first3++;
+    ++result;
+    ++first1;
+    ++first2;
+    ++first3;
   }
   return d;
 }

--- a/reference-implementation/unittests/tosa.cpp
+++ b/reference-implementation/unittests/tosa.cpp
@@ -628,16 +628,27 @@ TEST(tosa, broadcastable_op) {
 
 // Ternary elementwise ops
 TEST(tosa, select) {
-  using PredType = Tensor3D<bool, 1, 2, 3>;
-  using OperandType = Tensor3D<float, 1, 2, 3>;
-  PredType pred{true, false, true, false, false, true};
-  OperandType a{1000, 3, 15, 73, 6028, 1};
-  OperandType b{-1000, -3, -15, -73, -6028, -1};
-  OperandType expected_result{1000, -3, 15, -73, -6028, 1};
-  OperandType result = tosa::select<OperandType>(pred, a, b);
-  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  {
+    using PredType = Tensor1D<bool, 4>;
+    using OperandType = Tensor1D<int32_t, 4>;
+    PredType pred{true, false, true, false};
+    OperandType a{17, 23, 0, 10};
+    OperandType b{17, 10, 15, 200};
+    OperandType expected_result{17, 10, 0, 200};
+    OperandType result = tosa::select<OperandType>(pred, a, b);
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
+  }
+  {
+    using PredType = Tensor3D<bool, 1, 2, 3>;
+    using OperandType = Tensor3D<float, 1, 2, 3>;
+    PredType pred{true, false, true, false, false, true};
+    OperandType a{1000, 3, 15, 73, 6028, 1};
+    OperandType b{-1000, -3, -15, -73, -6028, -1};
+    OperandType expected_result{1000, -3, 15, -73, -6028, 1};
+    OperandType result = tosa::select<OperandType>(pred, a, b);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
 }
-
 // Other ops
 TEST(tosa, concat) {
   using Input1Type = Tensor2D<float, 2, 2>;
@@ -724,14 +735,14 @@ TEST(tosa, gather) {
     EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
   }
   {
-    using InputType = Tensor3D<float, 2, 4, 2>;  // N K C
-    using IndexType = Tensor2D<int32_t, 2, 3>;   // N W
-    using ResultType = Tensor3D<float, 2, 3, 2>; // N W C
+    using InputType = Tensor3D<int32_t, 2, 4, 2>;  // N K C
+    using IndexType = Tensor2D<int32_t, 2, 3>;     // N W
+    using ResultType = Tensor3D<int32_t, 2, 3, 2>; // N W C
     InputType input{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     IndexType indices{0, 1, 2, 3, 0, 1};
     ResultType expected_result{1, 2, 3, 4, 5, 6, 15, 16, 9, 10, 11, 12};
     ResultType result = tosa::gather<ResultType>(input, indices);
-    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+    EXPECT_THAT(result, Pointwise(Eq(), expected_result));
   }
 }
 

--- a/reference-implementation/unittests/tosa.cpp
+++ b/reference-implementation/unittests/tosa.cpp
@@ -626,7 +626,31 @@ TEST(tosa, broadcastable_op) {
             t1_arg1_broadcasted); // Just make sure it compiles in this test
 }
 
+// Ternary elementwise ops
+TEST(tosa, select) {
+  using PredType = Tensor3D<bool, 1, 2, 3>;
+  using OperandType = Tensor3D<float, 1, 2, 3>;
+  PredType pred{true, false, true, false, false, true};
+  OperandType a{1000, 3, 15, 73, 6028, 1};
+  OperandType b{-1000, -3, -15, -73, -6028, -1};
+  OperandType expected_result{1000, -3, 15, -73, -6028, 1};
+  OperandType result = tosa::select<OperandType>(pred, a, b);
+  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+}
+
 // Other ops
+TEST(tosa, concat) {
+  using Input1Type = Tensor2D<float, 2, 2>;
+  using Input2Type = Tensor2D<float, 2, 3>;
+  using ResultType = Tensor2D<float, 2, 5>;
+  Input1Type input1{1, 2, 3, 4};
+  Input2Type input2{5, 6, 7, 8, 9, 10};
+  ResultType expected_result{1, 2, 5, 6, 7, 3, 4, 8, 9, 10};
+  ResultType result =
+      tosa::concat<1, ResultType, Input1Type, Input2Type>(input1, input2);
+  EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+}
+
 TEST(tosa, depthwise_conv2d) {
   {
     // test for channel_multiplier=1
@@ -686,6 +710,29 @@ TEST(tosa, fully_connected) {
   ResultType result = tosa::fully_connected<ResultType>(input, weights, bias);
 
   EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+}
+
+TEST(tosa, gather) {
+  {
+    using InputType = Tensor3D<float, 1, 2, 2>;  // N K C
+    using IndexType = Tensor2D<int32_t, 1, 2>;   // N W
+    using ResultType = Tensor3D<float, 1, 2, 2>; // N W C
+    InputType input{1, 2, 3, 4};
+    IndexType indices{1, 0};
+    ResultType expected_result{3, 4, 1, 2};
+    ResultType result = tosa::gather<ResultType>(input, indices);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
+  {
+    using InputType = Tensor3D<float, 2, 4, 2>;  // N K C
+    using IndexType = Tensor2D<int32_t, 2, 3>;   // N W
+    using ResultType = Tensor3D<float, 2, 3, 2>; // N W C
+    InputType input{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    IndexType indices{0, 1, 2, 3, 0, 1};
+    ResultType expected_result{1, 2, 3, 4, 5, 6, 15, 16, 9, 10, 11, 12};
+    ResultType result = tosa::gather<ResultType>(input, indices);
+    EXPECT_THAT(result, Pointwise(FloatNear(EPSILON), expected_result));
+  }
 }
 
 TEST(tosa, matmul) {

--- a/test/Conversion/tosa-to-emitc.mlir
+++ b/test/Conversion/tosa-to-emitc.mlir
@@ -239,7 +239,16 @@ func.func @test_select_broadcast_input(%arg0: tensor<12x6x3xi1>, %arg1: tensor<1
   // CHECK: %1 = emitc.call "emitc::tosa::select"(%arg0, %0, %arg2) : (tensor<12x6x3xi1>, tensor<12x6x3xi32>, tensor<12x6x3xi32>) -> tensor<12x6x3xi32>
   %0 = "tosa.select"(%arg0, %arg1, %arg2) : (tensor<12x6x3xi1>, tensor<12x1x3xi32>, tensor<12x6x3xi32>) -> tensor<12x6x3xi32>
   return %0 : tensor<12x6x3xi32>
-} 
+}
+
+func.func @test_select_broadcast_all_elements(%arg0: tensor<12x6x1xi1>, %arg1: tensor<12x1x3xi32>, %arg2: tensor<12x1x3xi32>) -> tensor<12x6x3xi32> {
+  // CHECK: %0 = emitc.call "emitc::broadcast_in_dim"(%arg0) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<12x6x3xi1>]} : (tensor<12x6x1xi1>) -> tensor<12x6x3xi1>
+  // CHECK: %1 = emitc.call "emitc::broadcast_in_dim"(%arg1) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<12x6x3xi32>]} : (tensor<12x1x3xi32>) -> tensor<12x6x3xi32>
+  // CHECK: %2 = emitc.call "emitc::broadcast_in_dim"(%arg2) {args = [0 : index, dense<[0, 1, 2]> : tensor<3xi64>], template_args = [tensor<12x6x3xi32>]} : (tensor<12x1x3xi32>) -> tensor<12x6x3xi32>
+  // CHECK: %3 = emitc.call "emitc::tosa::select"(%0, %1, %2) : (tensor<12x6x3xi1>, tensor<12x6x3xi32>, tensor<12x6x3xi32>) -> tensor<12x6x3xi32>
+  %0 = "tosa.select"(%arg0, %arg1, %arg2) : (tensor<12x6x1xi1>, tensor<12x1x3xi32>, tensor<12x1x3xi32>) -> tensor<12x6x3xi32>
+  return %0 : tensor<12x6x3xi32>
+}
 
 // Other ops
 


### PR DESCRIPTION
* As MHLO already had an implementation for concatenate and the inputs/outputs are identical, moved the existing MHLO concatenate implementation into core_ops and referenced it from both. 
* The createBroadcastOpIfNeeded was initially implemented to support binary ops only. However, very small changes were required to enable it in supporting broadcasting for more than two inputs. This can be further expanded by allowing callOpBroadcastableConversion to take in more than two inputs, but it may require more substantial changes that might not be worth it for (what is currently) a single op. 