### PR TITLE
Implement an initial StableHLO to EmitC pass

### DIFF
--- a/include/emitc/Conversion/Passes.h
+++ b/include/emitc/Conversion/Passes.h
@@ -15,6 +15,7 @@
 
 #include "emitc/Conversion/ArithToEmitC/ArithToEmitC.h"
 #include "emitc/Conversion/MhloToEmitC/MhloToEmitC.h"
+#include "emitc/Conversion/StablehloToEmitC/StablehloToEmitC.h"
 #include "emitc/Conversion/TensorToEmitC/TensorToEmitC.h"
 #include "emitc/Conversion/TosaToEmitC/TosaToEmitC.h"
 

--- a/include/emitc/Conversion/Passes.td
+++ b/include/emitc/Conversion/Passes.td
@@ -23,6 +23,12 @@ def ConvertMHLOToEmitC : Pass<"convert-mhlo-to-emitc", "func::FuncOp"> {
   let dependentDialects = ["EmitCDialect"];
 }
 
+def ConvertStablehloToEmitC : Pass<"convert-stablehlo-to-emitc", "func::FuncOp"> {
+  let summary = "Convert from StableHLO dialect to EmitC dialect.";
+  let constructor = "createConvertStablehloToEmitCPass()";
+  let dependentDialects = ["EmitCDialect"];
+}
+
 def ConvertArithToEmitC : Pass<"convert-arith-to-emitc", "func::FuncOp"> {
   let summary = "Convert arith dialect to EmitC dialect, replacing IndexCastOp.";
   let constructor = "createConvertArithToEmitCPass()";

--- a/include/emitc/Conversion/StablehloToEmitC/StablehloToEmitC.h
+++ b/include/emitc/Conversion/StablehloToEmitC/StablehloToEmitC.h
@@ -1,0 +1,29 @@
+//===- StablehloToEmitC.h - Convert StableHLO to EmitC dialect --*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef EMITC_CONVERSION_STABLEHLOTOEMITC_H
+#define EMITC_CONVERSION_STABLEHLOTOEMITC_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+class ModuleOp;
+
+namespace func {
+class FuncOp;
+} // namespace func
+
+namespace emitc {
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertStablehloToEmitCPass();
+
+} // namespace emitc
+} // namespace mlir
+
+#endif // EMITC_CONVERSION_STABLEHLOTOEMITC_H

--- a/include/emitc/InitPasses.h
+++ b/include/emitc/InitPasses.h
@@ -39,6 +39,7 @@ inline void registerAllEmitCPasses() {
   registerConvertMHLOToEmitCPass();
   registerInsertEmitCMHLOIncludePass();
   registerMHLOToEmitCPipeline();
+  registerConvertStablehloToEmitCPass();
 #endif // EMITC_BUILD_HLO
   registerConvertArithToEmitCPass();
   registerConvertTensorToEmitCPass();

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(ArithToEmitC)
 add_subdirectory(MhloToEmitC)
+add_subdirectory(StablehloToEmitC)
 add_subdirectory(TensorToEmitC)
 add_subdirectory(TosaToEmitC)

--- a/lib/Conversion/StablehloToEmitC/CMakeLists.txt
+++ b/lib/Conversion/StablehloToEmitC/CMakeLists.txt
@@ -1,0 +1,18 @@
+if(EMITC_ENABLE_HLO)
+  add_mlir_library(MLIRStablehloToEmitC
+    StablehloToEmitC.cpp
+
+    DEPENDS
+    MLIREmitCDialect
+    MLIREmitCConversionPassIncGen
+    StablehloOpsIncGen
+
+    LINK_COMPONENTS
+    Core
+
+    LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRPass
+    MLIRTransformUtils
+  )
+endif()

--- a/lib/Conversion/StablehloToEmitC/StablehloToEmitC.cpp
+++ b/lib/Conversion/StablehloToEmitC/StablehloToEmitC.cpp
@@ -1,0 +1,119 @@
+//===- StablehloToEmitC.cpp - StableHLO to EmitC conversion ---------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements logic for lowering StableHLO dialect to EmitC dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include "../PassDetail.h"
+#include "emitc/Conversion/StablehloToEmitC/StablehloToEmitC.h"
+
+using namespace mlir;
+using namespace mlir::emitc;
+
+namespace {
+
+/// Convert a common `stablehlo` operation into an `emitc.call` operation.
+template <typename SrcOp, typename Adaptor = typename SrcOp::Adaptor>
+class CallOpConversion : public OpConversionPattern<SrcOp> {
+  using OpConversionPattern<SrcOp>::OpConversionPattern;
+
+public:
+  CallOpConversion(MLIRContext *ctx, StringRef funcName,
+                   bool explicitResultType = false,
+                   bool explicitOperandTypes = false)
+      : OpConversionPattern<SrcOp>(ctx), funcName(funcName),
+        explicitResultType(explicitResultType),
+        explicitOperandTypes(explicitOperandTypes) {}
+
+private:
+  LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringAttr callee = rewriter.getStringAttr(funcName);
+    ArrayAttr args;
+
+    SmallVector<Attribute, 4> templateArguments;
+
+    if (explicitResultType) {
+      Type type = srcOp.getType();
+      templateArguments.push_back(TypeAttr::get(type));
+    }
+
+    if (explicitOperandTypes) {
+      for (auto operand : adaptor.getOperands()) {
+        Type type = operand.getType();
+        templateArguments.push_back(TypeAttr::get(type));
+      }
+    }
+    ArrayAttr templateArgs;
+    if (!templateArguments.empty()) {
+      templateArgs = ArrayAttr::get(srcOp.getContext(), templateArguments);
+    }
+
+    rewriter.replaceOpWithNewOp<emitc::CallOp>(srcOp, srcOp.getType(), callee,
+                                               args, templateArgs,
+                                               adaptor.getOperands());
+
+    return success();
+  }
+
+  StringRef funcName;
+  // If set, use the result type of the operation as template parameter.
+  bool explicitResultType;
+  // If set, use the operand types as (additional) template parameters.
+  bool explicitOperandTypes;
+};
+
+} // namespace
+
+void populateStablehloToEmitcPatterns(MLIRContext *ctx,
+                                      RewritePatternSet &patterns) {
+  // Insert patterns for StableHLO unary elementwise ops.
+  patterns.add<CallOpConversion<stablehlo::AbsOp>>(ctx, "emitc::mhlo::abs");
+}
+
+namespace {
+
+struct ConvertStablehloToEmitCPass
+    : public ConvertStablehloToEmitCBase<ConvertStablehloToEmitCPass> {
+  /// Perform the lowering to EmitC dialect.
+  void runOnOperation() override {
+
+    ConversionTarget target(getContext());
+
+    target.addLegalDialect<emitc::EmitCDialect>();
+    target.addLegalDialect<stablehlo::StablehloDialect>();
+
+    // clang-format off
+    // StableHLO unary elementwise ops
+    target.addIllegalOp<stablehlo::AbsOp>();
+    // clang-format on
+
+    RewritePatternSet patterns(&getContext());
+    populateStablehloToEmitcPatterns(&getContext(), patterns);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::emitc::createConvertStablehloToEmitCPass() {
+  return std::make_unique<ConvertStablehloToEmitCPass>();
+}

--- a/test/Conversion/stablehlo-to-emitc.mlir
+++ b/test/Conversion/stablehlo-to-emitc.mlir
@@ -1,0 +1,9 @@
+// RUN: emitc-opt -convert-stablehlo-to-emitc %s | FileCheck %s
+
+// Unary elementwise ops
+
+func.func @stablehlo_abs(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+  // CHECK: emitc.call "emitc::mhlo::abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  %0 = "stablehlo.abs"(%arg0) : (tensor<2xf32>) -> tensor<2xf32>
+  return %0 : tensor<2xf32>
+}

--- a/tools/emitc-opt/CMakeLists.txt
+++ b/tools/emitc-opt/CMakeLists.txt
@@ -6,6 +6,7 @@ if(${EMITC_ENABLE_HLO})
     MLIRMHLOToEmitC
     MLIRMHLORegionOpsToEmitC
     MhloRegisterDialects
+    MLIRStablehloToEmitC
     )
   set(HLO_LIBS_DEPS
     MLIREmitCConversionPassIncGen

--- a/tools/emitc-opt/emitc-opt.cpp
+++ b/tools/emitc-opt/emitc-opt.cpp
@@ -14,6 +14,7 @@
 #include "emitc/InitPasses.h"
 #ifdef EMITC_BUILD_HLO
 #include "mhlo/IR/hlo_ops.h"
+#include "stablehlo/dialect/StablehloOps.h"
 #endif
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/Dialect.h"
@@ -40,6 +41,7 @@ int main(int argc, char **argv) {
   emitc::registerAllEmitCPasses();
 #ifdef EMITC_BUILD_HLO
   registry.insert<mlir::mhlo::MhloDialect>();
+  registry.insert<mlir::stablehlo::StablehloDialect>();
 #endif // EMITC_BUILD_HLO
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(


### PR DESCRIPTION
This adds an initianl StableHLO to EmitC pass. The pass is compiled if the option `EMITC_ENABLE_HLO` is set. For now, StableHLO ops converted to C++ rely on the reference implementation for MHLO ops. This will change in the future. When adding more ops, docs will be added and code might be moved from the MHLO conversions to the StableHLO conversions to avoid code duplication. If suitable, the MHLO conversions will be replaced by the StableHLO ones.