### PR TITLE
Add Copyright Notices

### DIFF
--- a/reference-implementation/include/emitc/arith.h
+++ b/reference-implementation/include/emitc/arith.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/core_ops.h
+++ b/reference-implementation/include/emitc/core_ops.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/mhlo.h
+++ b/reference-implementation/include/emitc/mhlo.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/tensor.h
+++ b/reference-implementation/include/emitc/tensor.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/tosa.h
+++ b/reference-implementation/include/emitc/tosa.h
@@ -1,3 +1,7 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+// Copyright Google LLC
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/tosa_eigen.h
+++ b/reference-implementation/include/emitc/tosa_eigen.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -1,3 +1,7 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+// Copyright Google LLC
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/include/emitc/utility.h
+++ b/reference-implementation/include/emitc/utility.h
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/arith.cpp
+++ b/reference-implementation/unittests/arith.cpp
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/mhlo.cpp
+++ b/reference-implementation/unittests/mhlo.cpp
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/tensor.cpp
+++ b/reference-implementation/unittests/tensor.cpp
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/tosa.cpp
+++ b/reference-implementation/unittests/tosa.cpp
@@ -1,3 +1,7 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+// Copyright Google LLC
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/tosa_eigen.cpp
+++ b/reference-implementation/unittests/tosa_eigen.cpp
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -1,3 +1,6 @@
+// Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
+//           Forschung e.V.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
Add copyright notices to the reference implementation for the case of
re-licensing.

As part of https://reviews.llvm.org/D146483, part of the reference
implementation is forked. Even if not as part of this pull request, it
might be of interest to change the license from `Apache-2.0` to
`Apache-2.0 WITH LLVM-exception`. The copyright notices can help to
facilitate this.