### PR TITLE
Add .get() method to Tensor<...>.

### DIFF
--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -114,7 +114,7 @@ public:
     assert(data.size() == size());
   }
 
-  T* get() { return data.data(); }
+  T *get() { return data.data(); }
 
   static constexpr size_t dim(size_t index) {
     assert(0 <= index && index < rank());

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -114,6 +114,8 @@ public:
     assert(data.size() == size());
   }
 
+  T* get() { return data.data(); }
+
   static constexpr size_t dim(size_t index) {
     assert(0 <= index && index < rank());
     constexpr std::array<size_t, rank()> s = {Shape...};

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -100,6 +100,8 @@ struct switch_t<case_t<B, T>> {
 };
 } // namespace detail
 
+/// The elements of a Tensor are stored contiguously in memory in a
+/// column-major layout.
 template <typename T, size_t... Shape>
 class Tensor {
 public:

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -101,7 +101,7 @@ struct switch_t<case_t<B, T>> {
 } // namespace detail
 
 /// The elements of a Tensor are stored contiguously in memory in a
-/// column-major layout.
+/// row-major layout.
 template <typename T, size_t... Shape>
 class Tensor {
 public:

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -1,5 +1,6 @@
 // Copyright Fraunhofer-Gesellschaft zur Förderung der angewandten
 //           Forschung e.V.
+// Copyright Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -97,6 +97,18 @@ TEST(types, tensor_of_bool) {
   EXPECT_TRUE(t2(1, 1));
 }
 
+TEST(types, tensor_get) {
+  Tensor2D<int, 2, 2> t{1, 2, 3, 4};
+  int* data = t.get();
+
+  // Test that the linear layout of the data array corresponds to the
+  // columnar layout of the multidimensional tensor
+  EXPECT_EQ(data[2*0 + 0], t(0, 0));
+  EXPECT_EQ(data[2*0 + 1], t(0, 1));
+  EXPECT_EQ(data[2*1 + 0], t(1, 0));
+  EXPECT_EQ(data[2*1 + 1], t(1, 1));
+}
+
 TEST(types, default_constructor_0d) {
   Tensor0D<float> tensor;
 

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -100,14 +100,14 @@ TEST(types, tensor_of_bool) {
 
 TEST(types, tensor_get) {
   Tensor2D<int, 2, 2> t{1, 2, 3, 4};
-  int* data = t.get();
+  int *data = t.get();
 
   // Test that the linear layout of the data array corresponds to the
   // columnar layout of the multidimensional tensor
-  EXPECT_EQ(data[2*0 + 0], t(0, 0));
-  EXPECT_EQ(data[2*0 + 1], t(0, 1));
-  EXPECT_EQ(data[2*1 + 0], t(1, 0));
-  EXPECT_EQ(data[2*1 + 1], t(1, 1));
+  EXPECT_EQ(data[2 * 0 + 0], t(0, 0));
+  EXPECT_EQ(data[2 * 0 + 1], t(0, 1));
+  EXPECT_EQ(data[2 * 1 + 0], t(1, 0));
+  EXPECT_EQ(data[2 * 1 + 1], t(1, 1));
 }
 
 TEST(types, default_constructor_0d) {

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -103,7 +103,7 @@ TEST(types, tensor_get) {
   int *data = t.get();
 
   // Test that the linear layout of the data array corresponds to the
-  // columnar layout of the multidimensional tensor
+  // row-major layout of the multidimensional tensor
   EXPECT_EQ(data[2 * 0 + 0], t(0, 0));
   EXPECT_EQ(data[2 * 0 + 1], t(0, 1));
   EXPECT_EQ(data[2 * 1 + 0], t(1, 0));


### PR DESCRIPTION
This is used in the MGLO LLVM integration of emitc'ed models. Our infrastructure internally uses T* buffers to communicate between LLVM and the model (this was used to abstract away the details of TF/TFLite runtime vs interacting with a model in a python host vs EmitC) and so we need to be able to extract the underlying buffer of a EmitC Tensor.

This places a (light) data layout restriction on the Tensor implementation, as we need it to be in a columnar layout. This is already what the implementation did, so there is nothing too surprising here. I have added a unit test to enforce this restriction on the underlying buffer layout.