### PR TITLE
Fix `Tensor` with element type bool

### DIFF
--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -91,7 +91,8 @@ struct switch_t<case_t<B, T>> {
 
 // Wrapper class to prevent use of the template specialization for
 // std::vector<bool> in the Tensor class
-template <typename T> class TypeWrapper {
+template <typename T>
+class TypeWrapper {
 public:
   TypeWrapper() = default;
 
@@ -110,7 +111,8 @@ private:
   T value;
 };
 
-template <typename T, typename Iterator> class IteratorWrapper {
+template <typename T, typename Iterator>
+class IteratorWrapper {
 public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = T;

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <functional>
 #include <numeric>
+#include <type_traits>
 #include <vector>
 
 #include "emitc/utility.h"

--- a/reference-implementation/include/emitc/types.h
+++ b/reference-implementation/include/emitc/types.h
@@ -171,7 +171,7 @@ public:
   using value_type = T;
   static_assert(sizeof(T) == sizeof(storage_type),
                 "storage_type has a different size than the raw type T");
-  static_assert(std::is_standard_layout_v<storage_type>,
+  static_assert(std::is_standard_layout<storage_type>::value,
                 "Cannot access data from storage_type as T*");
   using iterator =
       detail::IteratorWrapper<T, typename std::vector<storage_type>::iterator>;

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -6,6 +6,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <utility>
+
 #include "gmock/gmock.h"
 
 #include "emitc/types.h"
@@ -388,6 +390,72 @@ TEST(types, size_4d) {
   Tensor4D<int8_t, 1, 5, 6, 2> tensor2;
 
   EXPECT_EQ(60, tensor2.size());
+}
+
+TEST(types, iterator) {
+  Tensor<float>::iterator default_constructed;
+  Tensor<float>::iterator copy_constructed(default_constructed);
+  Tensor<float>::iterator copy_assigned = copy_constructed;
+  (void)copy_assigned;
+
+  Tensor<int32_t, 2> tensor{24, 42};
+  auto i = tensor.begin();
+  auto j = tensor.begin();
+  ++j;
+  EXPECT_EQ(*i, 24);
+  EXPECT_EQ(*j, 42);
+
+  std::swap(i, j);
+  EXPECT_EQ(*i, 42);
+  EXPECT_EQ(*j, 24);
+  std::swap(i, j);
+
+  EXPECT_TRUE(i == i);
+  EXPECT_FALSE(i == j);
+  EXPECT_TRUE(i != j);
+  EXPECT_FALSE(i != i);
+
+  auto k = tensor.begin();
+  EXPECT_EQ(*k, *i);
+  EXPECT_TRUE(k == i);
+  EXPECT_EQ(*k++, *i);
+  EXPECT_TRUE(k++ == j);
+  EXPECT_TRUE(k == tensor.end());
+
+  *i = 242;
+  EXPECT_EQ(*i, 242);
+  EXPECT_EQ(*i, *(tensor.begin()));
+}
+
+TEST(types, const_iterator) {
+  Tensor<float>::const_iterator default_constructed;
+  Tensor<float>::const_iterator copy_constructed(default_constructed);
+  Tensor<float>::const_iterator copy_assigned = copy_constructed;
+  (void)copy_assigned;
+
+  Tensor<int32_t, 2> const tensor{24, 42};
+  auto i = tensor.begin();
+  auto j = tensor.begin();
+  ++j;
+  EXPECT_EQ(*i, 24);
+  EXPECT_EQ(*j, 42);
+
+  std::swap(i, j);
+  EXPECT_EQ(*i, 42);
+  EXPECT_EQ(*j, 24);
+  std::swap(i, j);
+
+  EXPECT_TRUE(i == i);
+  EXPECT_FALSE(i == j);
+  EXPECT_TRUE(i != j);
+  EXPECT_FALSE(i != i);
+
+  auto k = tensor.begin();
+  EXPECT_EQ(*k, *i);
+  EXPECT_TRUE(k == i);
+  EXPECT_EQ(*k++, *i);
+  EXPECT_TRUE(k++ == j);
+  EXPECT_TRUE(k == tensor.end());
 }
 
 TEST(types, meta_get_element_type) {

--- a/reference-implementation/unittests/types.cpp
+++ b/reference-implementation/unittests/types.cpp
@@ -89,15 +89,24 @@ TEST(types, tensor_of_bool) {
 }
 
 TEST(types, tensor_get) {
-  Tensor2D<int, 2, 2> t{1, 2, 3, 4};
-  int *data = t.get();
+  {
+    Tensor2D<int, 2, 2> t{1, 2, 3, 4};
+    int *data = t.get();
 
-  // Test that the linear layout of the data array corresponds to the
-  // row-major layout of the multidimensional tensor
-  EXPECT_EQ(data[2 * 0 + 0], t(0, 0));
-  EXPECT_EQ(data[2 * 0 + 1], t(0, 1));
-  EXPECT_EQ(data[2 * 1 + 0], t(1, 0));
-  EXPECT_EQ(data[2 * 1 + 1], t(1, 1));
+    // Test that the linear layout of the data array corresponds to the
+    // row-major layout of the multidimensional tensor
+    EXPECT_EQ(data[2 * 0 + 0], t(0, 0));
+    EXPECT_EQ(data[2 * 0 + 1], t(0, 1));
+    EXPECT_EQ(data[2 * 1 + 0], t(1, 0));
+    EXPECT_EQ(data[2 * 1 + 1], t(1, 1));
+  }
+  { // Test the correct handling of a tensor with type bool
+    Tensor1D<bool, 2> t{false, true};
+    bool *data = t.get();
+
+    EXPECT_EQ(data[0], t(0));
+    EXPECT_EQ(data[1], t(1));
+  }
 }
 
 TEST(types, default_constructor_0d) {


### PR DESCRIPTION
Introduce classes `TypeWrapper` and `IteratorWrapper` to prevent use of the template specialization for `std::vector<bool>` in the `Tensor` class.