### PR TITLE
Replace `{i,getI}64ElementsAttr`

### DIFF
--- a/lib/Conversion/StablehloToEmitC/StablehloRegionOpsToEmitC.cpp
+++ b/lib/Conversion/StablehloToEmitC/StablehloRegionOpsToEmitC.cpp
@@ -27,15 +27,6 @@ using namespace mlir::emitc;
 namespace {
 
 /// Common functions.
-/// Adopted from mlir-hlo.
-DenseIntElementsAttr i64ElementsAttr(int64_t value, size_t count,
-                                     MLIRContext *ctx) {
-  RankedTensorType ty = RankedTensorType::get({static_cast<int64_t>(count)},
-                                              IntegerType::get(ctx, 64));
-  SmallVector<int64_t, 4> values(count, value);
-  return DenseIntElementsAttr::get(ty, values);
-}
-
 SmallVector<Attribute, 2> indexSequence(int64_t n, MLIRContext *ctx) {
   return llvm::to_vector<2>(
       llvm::map_range(llvm::seq<int64_t>(0, n), [&ctx](int64_t i) -> Attribute {
@@ -202,14 +193,14 @@ private:
 
     size_t dim = op.getResult(0).getType().cast<RankedTensorType>().getRank();
     arguments.push_back(op.getWindowDimensions());
-    arguments.push_back(
-        op.getWindowStrides().value_or(i64ElementsAttr(1, dim, ctx)));
-    arguments.push_back(
-        op.getBaseDilations().value_or(i64ElementsAttr(1, dim, ctx)));
-    arguments.push_back(
-        op.getBaseDilations().value_or(i64ElementsAttr(1, dim, ctx)));
-    arguments.push_back(
-        op.getPadding().value_or(i64ElementsAttr(0, 2 * dim, ctx)));
+    arguments.push_back(op.getWindowStrides().value_or(
+        builder.getI64TensorAttr(SmallVector<int64_t>(dim, 1))));
+    arguments.push_back(op.getBaseDilations().value_or(
+        builder.getI64TensorAttr(SmallVector<int64_t>(dim, 1))));
+    arguments.push_back(op.getBaseDilations().value_or(
+        builder.getI64TensorAttr(SmallVector<int64_t>(dim, 1))));
+    arguments.push_back(op.getPadding().value_or(
+        builder.getI64TensorAttr(SmallVector<int64_t>(2 * dim, 0))));
     arguments.push_back(SymbolRefAttr::get(ctx, funcOp.getName()));
 
     ArrayAttr args = ArrayAttr::get(ctx, arguments);

--- a/lib/Conversion/TosaToEmitC/TosaToEmitC.cpp
+++ b/lib/Conversion/TosaToEmitC/TosaToEmitC.cpp
@@ -27,14 +27,6 @@ using namespace mlir::emitc;
 namespace {
 
 /// Common functions.
-DenseIntElementsAttr getI64ElementsAttr(const ArrayRef<long> values,
-                                        MLIRContext *ctx) {
-  RankedTensorType ty = RankedTensorType::get(
-      {static_cast<int64_t>(values.size())}, IntegerType::get(ctx, 64));
-
-  return DenseIntElementsAttr::get(ty, values);
-}
-
 SmallVector<Attribute, 2> indexSequence(int64_t n, MLIRContext *ctx) {
   return llvm::to_vector<2>(
       llvm::map_range(llvm::seq<int64_t>(0, n), [&ctx](int64_t i) -> Attribute {
@@ -115,9 +107,9 @@ private:
     ArrayAttr args = rewriter.getArrayAttr({
       rewriter.getIndexAttr(0),
       rewriter.getIndexAttr(1),
-      getI64ElementsAttr(convOp.getPad(), convOp.getContext()),
-      getI64ElementsAttr(convOp.getStride(), convOp.getContext()),
-      getI64ElementsAttr(convOp.getDilation(), convOp.getContext()),
+      rewriter.getI64TensorAttr(convOp.getPad()),
+      rewriter.getI64TensorAttr(convOp.getStride()),
+      rewriter.getI64TensorAttr(convOp.getDilation()),
     });
     // clang-format on
 
@@ -161,9 +153,9 @@ private:
     // clang-format off
     ArrayAttr args = rewriter.getArrayAttr({
       rewriter.getIndexAttr(0),
-      getI64ElementsAttr(poolOp.getPad(), poolOp.getContext()),
-      getI64ElementsAttr(poolOp.getStride(), poolOp.getContext()),
-      getI64ElementsAttr(poolOp.getKernel(), poolOp.getContext()),
+      rewriter.getI64TensorAttr(poolOp.getPad()),
+      rewriter.getI64TensorAttr(poolOp.getStride()),
+      rewriter.getI64TensorAttr(poolOp.getKernel()),
     });
     // clang-format on
 


### PR DESCRIPTION
Replaces `{i,getI}64ElementsAttr` with `getI64TensorAttr`.

Closes #402